### PR TITLE
feat: 웹용 선물박스 열기 API 구현

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -77,6 +77,22 @@ public class GiftBoxController {
         return DataResponseDto.from(giftBoxService.openGiftBox(giftBoxId));
     }
 
+    @Operation(summary = "(WEB) 선물박스 열기", description = """
+        선물이 없을 경우 응답에서 gift 객체가 제외됩니다. <br>
+        00한 후 7일이 경과되면 예외 처리 <br>
+        """)
+    @ApiErrorCodeExamples({
+        ErrorCode.GIFTBOX_NOT_FOUND,
+        ErrorCode.GIFTBOX_ALREADY_DELETED,
+        ErrorCode.GIFTBOX_URL_EXPIRED
+    })
+    @GetMapping("/web/{giftBoxUuid}")
+    public DataResponseDto<GiftBoxResponse> openGiftBoxForWeb(
+        @PathVariable("giftBoxUuid") String giftBoxUuid
+    ) {
+        return DataResponseDto.from(giftBoxService.openGiftBoxForWeb(giftBoxUuid));
+    }
+
     @Operation(summary = "주고받은 선물박스 조회")
     @Parameter(in = ParameterIn.QUERY,
         description = "한 페이지에 보여줄 선물박스 개수. 기본값은 6개",

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -173,25 +173,10 @@ public class GiftBoxService {
 
         checkIfGiftBoxOpenable(member, giftBox);
 
-        BoxResponse boxResponse = BoxResponse.from(giftBox.getBox());
-        EnvelopeResponse envelopeResponse = EnvelopeResponse.from(
-            giftBox.getLetter().getEnvelope());
-        List<PhotoResponse> photos = photoReader.findAllByGiftBox(giftBox).stream()
-            .map(PhotoResponse::from)
-            .sorted(Comparator.comparingInt(PhotoResponse::sequence))
-            .toList();
-        List<StickerResponse> stickers = giftBoxStickerReader.findAllByGiftBox(giftBox).stream()
-            .map(StickerResponse::from)
-            .sorted(Comparator.comparingInt(StickerResponse::location))
-            .toList();
+        return toGiftBoxResponse(giftBox);
+    }
 
-        GiftResponse giftResponse = null;
-        if (giftBox.getGift() != null) {
-            giftResponse = GiftResponse.from(giftBox.getGift());
-        }
 
-        return GiftBoxResponse.of(giftBox, boxResponse, envelopeResponse, photos, stickers,
-            giftResponse);
     }
 
     // TODO: 성능 개선 필요
@@ -375,5 +360,27 @@ public class GiftBoxService {
         }
 
         return mainGiftBoxResponse;
+    }
+
+    public GiftBoxResponse toGiftBoxResponse(GiftBox giftBox) {
+        BoxResponse boxResponse = BoxResponse.from(giftBox.getBox());
+        EnvelopeResponse envelopeResponse = EnvelopeResponse.from(
+            giftBox.getLetter().getEnvelope());
+        List<PhotoResponse> photos = photoReader.findAllByGiftBox(giftBox).stream()
+            .map(PhotoResponse::from)
+            .sorted(Comparator.comparingInt(PhotoResponse::sequence))
+            .toList();
+        List<StickerResponse> stickers = giftBoxStickerReader.findAllByGiftBox(giftBox).stream()
+            .map(StickerResponse::from)
+            .sorted(Comparator.comparingInt(StickerResponse::location))
+            .toList();
+
+        GiftResponse giftResponse = null;
+        if (giftBox.getGift() != null) {
+            giftResponse = GiftResponse.from(giftBox.getGift());
+        }
+
+        return GiftBoxResponse.of(giftBox, boxResponse, envelopeResponse, photos, stickers,
+            giftResponse);
     }
 }

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -176,7 +176,17 @@ public class GiftBoxService {
         return toGiftBoxResponse(giftBox);
     }
 
+    public GiftBoxResponse openGiftBoxForWeb(String giftBoxUuid) {
+        GiftBox giftBox = giftBoxReader.findByUuid(giftBoxUuid);
 
+        LocalDateTime sentDate = giftBox.getUpdatedAt();
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.minusDays(7).isAfter(sentDate)) {
+            throw new UnsupportedException(ErrorCode.GIFTBOX_URL_EXPIRED);
+        }
+        
+        return toGiftBoxResponse(giftBox);
     }
 
     // TODO: 성능 개선 필요

--- a/packy-api/src/main/java/com/dilly/global/config/SecurityConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/SecurityConfig.java
@@ -65,7 +65,8 @@ public class SecurityConfig {
 						"/api/v1/admin/design/profiles",
 						"/api/v1/auth/sign-up",
 						"/api/v1/auth/sign-in/**",
-						"/api/v1/auth/reissue"
+						"/api/v1/auth/reissue",
+						"/api/v1/giftboxes/web/**"
 					).permitAll()
 					.anyRequest().authenticated()
 			)

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
     GIFTBOX_ALREADY_OPENDED(HttpStatus.CONFLICT, "이미 열린 선물입니다."),
     GIFTBOX_ACCESS_DENIED(HttpStatus.FORBIDDEN, "선물박스에 접근할 수 없습니다."),
     GIFTBOX_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 삭제된 선물박스입니다."),
+    GIFTBOX_URL_EXPIRED(HttpStatus.BAD_REQUEST, "URL이 만료되었습니다."),
 
     // Version
     FAILED_TO_EXTRACT_VERSION(HttpStatus.BAD_REQUEST, "사용자 버전을 추출하는데 실패했습니다."),

--- a/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxReader.java
+++ b/packy-domain/src/main/java/com/dilly/gift/adaptor/GiftBoxReader.java
@@ -28,6 +28,11 @@ public class GiftBoxReader {
             .orElseThrow(() -> new EntityNotFoundException(ErrorCode.GIFTBOX_NOT_FOUND));
     }
 
+    public GiftBox findByUuid(String uuid) {
+        return giftBoxRepository.findByUuid(uuid)
+            .orElseThrow(() -> new EntityNotFoundException(ErrorCode.GIFTBOX_NOT_FOUND));
+    }
+
     public GiftBox findByLetter(Letter letter) {
         return giftBoxRepository.findByLetter(letter);
     }

--- a/packy-domain/src/main/java/com/dilly/gift/dao/GiftBoxRepository.java
+++ b/packy-domain/src/main/java/com/dilly/gift/dao/GiftBoxRepository.java
@@ -5,11 +5,14 @@ import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.gift.domain.letter.Letter;
 import com.dilly.member.domain.Member;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GiftBoxRepository extends JpaRepository<GiftBox, Long> {
 	
 	GiftBox findTopByOrderByIdDesc();
+
+    Optional<GiftBox> findByUuid(String uuid);
 
     GiftBox findByLetter(Letter letter);
 


### PR DESCRIPTION
## 🛰️ Issue Number
#214 

## 🪐 작업 내용
- 웹에서 사용할 선물박스 열기 API를 구현했습니다.
- UUID를 사용하여 선물박스에 접근하도록 코드를 구현했습니다.
  - 웹의 경우 모바일과 다르게 URL이 사용자에게 노출되기 때문에, PK인 ID 값을 사용하는 것은 보안적으로 위험하다고 판단했습니다.
- 회원가입을 하지 않은 사람도 선물박스 내용을 확인할 수 있도록 SecurityConfig에서 화이트리스트를 수정하였습니다.
- 선물박스를 보낸 지 7일이 지나면 선물박스를 열지 못하도록 예외 처리를 했습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
