### PR TITLE
fix: JWT 토큰을 생성할 때 Refresh Token 만료 기한을 설정하지 않도록 수정

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -79,7 +79,7 @@ public class GiftBoxController {
 
     @Operation(summary = "(WEB) 선물박스 열기", description = """
         선물이 없을 경우 응답에서 gift 객체가 제외됩니다. <br>
-        00한 후 7일이 경과되면 예외 처리 <br>
+        선물박스를 보낸 뒤 7일이 지나면 선물박스를 열 수 없습니다. <br>
         """)
     @ApiErrorCodeExamples({
         ErrorCode.GIFTBOX_NOT_FOUND,

--- a/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
+++ b/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
@@ -56,6 +56,7 @@ public class TokenProvider {
 
 		// Refresh Token 생성
 		String refreshToken = Jwts.builder()
+			.setSubject(member.getId().toString())
 			.signWith(key, SignatureAlgorithm.HS512)
 			.compact();
 

--- a/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
+++ b/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
@@ -32,7 +32,6 @@ public class TokenProvider {
 	private static final String AUTHORITIES_KEY = "auth";
 	private static final String BEARER_TYPE = "Bearer";
 	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 30;            // 30분
-	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7;  // 7일
 
 	private final Key key;
 
@@ -44,7 +43,6 @@ public class TokenProvider {
 	public JwtResponse generateJwt(Member member) {
 		long now = (new Date()).getTime();
 		Date accessTokenExpiresIn = new Date(now + (ACCESS_TOKEN_EXPIRE_TIME));
-		Date refreshTokenExpiresIn = new Date(now + (REFRESH_TOKEN_EXPIRE_TIME));
 
 		// Access Token 생성
 		String accessToken = Jwts.builder()
@@ -58,7 +56,6 @@ public class TokenProvider {
 
 		// Refresh Token 생성
 		String refreshToken = Jwts.builder()
-			.setExpiration(refreshTokenExpiresIn)
 			.signWith(key, SignatureAlgorithm.HS512)
 			.compact();
 


### PR DESCRIPTION
## 🛰️ Issue Number
#215 

## 🪐 작업 내용
- Refresh Token의 유효 기간을 제거했습니다.
- #216 에서 미완성으로 작성한 Swagger API 설명을 보완했습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
