### PR TITLE
fix: 박스 디자인 조회, 선물박스 열기 API 응답값에 로띠 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/admin/dto/response/BoxImgResponse.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/BoxImgResponse.java
@@ -17,7 +17,9 @@ public record BoxImgResponse(
 	@Schema(example = "www.example.com")
     String boxSet,
 	@Schema(example = "www.example.com")
-    String boxTop
+	String boxTop,
+	@Schema(example = "www.example.com")
+	String boxLottie
 ) {
 
 	public static BoxImgResponse from(Box box) {
@@ -28,6 +30,7 @@ public record BoxImgResponse(
             .boxSmall(box.getSmallImgUrl())
             .boxSet(box.getSetImgUrl())
             .boxTop(box.getTopImgUrl())
+			.boxLottie(box.getLottieMakeUrl())
             .build();
     }
 }

--- a/packy-api/src/main/java/com/dilly/gift/dto/response/BoxResponse.java
+++ b/packy-api/src/main/java/com/dilly/gift/dto/response/BoxResponse.java
@@ -10,9 +10,10 @@ public record BoxResponse(
     Long id,
     @Schema(example = "www.example.com")
     String boxNormal,
-
     @Schema(example = "www.example.com")
-    String boxTop
+    String boxTop,
+    @Schema(example = "www.example.com")
+    String boxLottie
 ) {
 
     public static BoxResponse from(Box box) {
@@ -20,6 +21,7 @@ public record BoxResponse(
             .id(box.getId())
             .boxNormal(box.getNormalImgUrl())
             .boxTop(box.getTopImgUrl())
+            .boxLottie(box.getLottieArrivedUrl())
             .build();
     }
 }

--- a/packy-domain/src/main/java/com/dilly/gift/domain/Box.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/Box.java
@@ -26,4 +26,8 @@ public class Box {
 	private String topImgUrl;
 
 	private String kakaoMessageImgUrl;
+
+	private String lottieMakeUrl;
+
+	private String lottieArrivedUrl;
 }

--- a/packy-domain/src/main/resources/db/migration/V35__add_lottie_column_in_box_table.sql
+++ b/packy-domain/src/main/resources/db/migration/V35__add_lottie_column_in_box_table.sql
@@ -1,0 +1,7 @@
+-- 컬럼 추가
+ALTER TABLE box ADD COLUMN lottie_make_url VARCHAR(255) NOT NULL;
+ALTER TABLE box ADD COLUMN lottie_arrived_url VARCHAR(255) NOT NULL;
+
+-- 데이터 삽입
+UPDATE box SET lottie_make_url = CONCAT('https://packy-bucket.s3.ap-northeast-2.amazonaws.com/admin/design/Box_motion/make/Box_motion_make_', id, '.json');
+UPDATE box SET lottie_arrived_url = CONCAT('https://packy-bucket.s3.ap-northeast-2.amazonaws.com/admin/design/Box_motion/arr/Box_motion_arr_', id, '.json');


### PR DESCRIPTION
## 🛰️ Issue Number
#225

## 🪐 작업 내용
- 박스 디자인 조회 API와 선물박스 열기 API 응답값에 로띠를 추가하였습니다. _(커밋 메시지 빠르게 적느라 박스 디자인 조회 API를 만들기 API라고 적어버렸네요 ... 🫠)_
- 컬럼 추가에 따라 flyway 스크립트를 추가하였습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
