### PR TITLE
fix: 웹용 선물박스 열기 API 7일 제한 제거

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -179,12 +179,12 @@ public class GiftBoxService {
     public GiftBoxResponse openGiftBoxForWeb(String giftBoxUuid) {
         GiftBox giftBox = giftBoxReader.findByUuid(giftBoxUuid);
 
-        LocalDateTime sentDate = giftBox.getUpdatedAt();
-        LocalDateTime now = LocalDateTime.now();
+//        LocalDateTime sentDate = giftBox.getUpdatedAt();
+//        LocalDateTime now = LocalDateTime.now();
 
-        if (now.minusDays(7).isAfter(sentDate)) {
-            throw new UnsupportedException(ErrorCode.GIFTBOX_URL_EXPIRED);
-        }
+//        if (now.minusDays(7).isAfter(sentDate)) {
+//            throw new UnsupportedException(ErrorCode.GIFTBOX_URL_EXPIRED);
+//        }
         
         return toGiftBoxResponse(giftBox);
     }


### PR DESCRIPTION
## 🛰️ Issue Number
#214

## 🪐 작업 내용
웹 출시 계획 변경에 따라 보낸지 일주일이 지나면 선물박스를 열 수 없도록 하는 로직을 임시로 주석 처리했습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
