### PR TITLE
fix: 웹용 선물박스 열기 API id와 uuid 둘 다 사용 가능하도록 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mysql-docker:
     image: mysql:latest

--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -84,13 +84,14 @@ public class GiftBoxController {
     @ApiErrorCodeExamples({
         ErrorCode.GIFTBOX_NOT_FOUND,
         ErrorCode.GIFTBOX_ALREADY_DELETED,
-        ErrorCode.GIFTBOX_URL_EXPIRED
+        ErrorCode.GIFTBOX_URL_EXPIRED,
+        ErrorCode.INVALID_INPUT_VALUE
     })
-    @GetMapping("/web/{giftBoxUuid}")
+    @GetMapping("/web/{giftBoxId}")
     public DataResponseDto<GiftBoxResponse> openGiftBoxForWeb(
-        @PathVariable("giftBoxUuid") String giftBoxUuid
+        @PathVariable("giftBoxId") String giftBoxId
     ) {
-        return DataResponseDto.from(giftBoxService.openGiftBoxForWeb(giftBoxUuid));
+        return DataResponseDto.from(giftBoxService.openGiftBoxForWeb(giftBoxId));
     }
 
     @Operation(summary = "주고받은 선물박스 조회")

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -48,6 +48,7 @@ import com.dilly.gift.dto.response.PhotoResponseDto.PhotoResponse;
 import com.dilly.gift.dto.response.StickerResponse;
 import com.dilly.gift.dto.response.WaitingGiftBoxResponse;
 import com.dilly.global.util.SecurityUtil;
+import com.dilly.global.util.validator.UuidValidator;
 import com.dilly.member.adaptor.MemberReader;
 import com.dilly.member.domain.Member;
 import java.time.LocalDateTime;
@@ -176,8 +177,18 @@ public class GiftBoxService {
         return toGiftBoxResponse(giftBox);
     }
 
-    public GiftBoxResponse openGiftBoxForWeb(String giftBoxUuid) {
-        GiftBox giftBox = giftBoxReader.findByUuid(giftBoxUuid);
+    public GiftBoxResponse openGiftBoxForWeb(String giftBoxId) {
+        GiftBox giftBox;
+
+        if (UuidValidator.isValidUUID(giftBoxId)) {
+            giftBox = giftBoxReader.findByUuid(giftBoxId);
+        } else {
+            try {
+                giftBox = giftBoxReader.findById(Long.parseLong(giftBoxId));
+            } catch (NumberFormatException e) {
+                throw new UnsupportedException(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
 
 //        LocalDateTime sentDate = giftBox.getUpdatedAt();
 //        LocalDateTime now = LocalDateTime.now();

--- a/packy-api/src/main/java/com/dilly/global/util/SecurityUtil.java
+++ b/packy-api/src/main/java/com/dilly/global/util/SecurityUtil.java
@@ -2,11 +2,14 @@ package com.dilly.global.util;
 
 import com.dilly.exception.AuthorizationFailedException;
 import com.dilly.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 @Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SecurityUtil {
 
 	public static Long getMemberId() {

--- a/packy-api/src/main/java/com/dilly/global/util/TextUtil.java
+++ b/packy-api/src/main/java/com/dilly/global/util/TextUtil.java
@@ -2,11 +2,11 @@ package com.dilly.global.util;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TextUtil {
-
-    private TextUtil() {
-    }
     
     private static final Pattern graphemePattern = Pattern.compile("\\X");
 

--- a/packy-api/src/main/java/com/dilly/global/util/validator/UuidValidator.java
+++ b/packy-api/src/main/java/com/dilly/global/util/validator/UuidValidator.java
@@ -1,7 +1,10 @@
 package com.dilly.global.util.validator;
 
 import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UuidValidator {
 
     public static boolean isValidUUID(String value) {

--- a/packy-api/src/main/java/com/dilly/global/util/validator/UuidValidator.java
+++ b/packy-api/src/main/java/com/dilly/global/util/validator/UuidValidator.java
@@ -1,0 +1,13 @@
+package com.dilly.global.util.validator;
+
+import java.util.regex.Pattern;
+
+public class UuidValidator {
+
+    public static boolean isValidUUID(String value) {
+        final Pattern uuidPattern =
+            Pattern.compile(
+                "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+        return value != null && uuidPattern.matcher(value).matches();
+    }
+}

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
@@ -26,12 +26,12 @@ import com.dilly.gift.dto.response.WaitingGiftBoxResponse;
 import com.dilly.global.IntegrationTestSupport;
 import com.dilly.global.WithCustomMockUser;
 import com.dilly.global.util.SecurityUtil;
+import com.dilly.global.util.validator.UuidValidator;
 import com.dilly.member.domain.Member;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -97,7 +97,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                 assertThat(giftBox.getGiftBoxType()).isEqualTo(GiftBoxType.PRIVATE);
 
                 assertThat(giftBoxIdResponse.id()).isEqualTo(giftBox.getId());
-                assertTrue(isValidUUID(giftBoxIdResponse.uuid()));
+                assertTrue(UuidValidator.isValidUUID(giftBoxIdResponse.uuid()));
                 assertThat(giftBoxIdResponse.kakaoMessageImgUrl()).isEqualTo(
                     giftBox.getBox().getKakaoMessageImgUrl());
             }),
@@ -132,7 +132,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                 assertThat(giftBox.getGiftBoxType()).isEqualTo(GiftBoxType.PRIVATE);
 
                 assertThat(giftBoxIdResponse.id()).isEqualTo(giftBox.getId());
-                assertTrue(isValidUUID(giftBoxIdResponse.uuid()));
+                assertTrue(UuidValidator.isValidUUID(giftBoxIdResponse.uuid()));
                 assertThat(giftBoxIdResponse.kakaoMessageImgUrl()).isEqualTo(
                     giftBox.getBox().getKakaoMessageImgUrl());
             })
@@ -330,12 +330,5 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
             assertThat(result.get(0).id()).isEqualTo(lastGiftBoxId);
             assertThat(result.get(5).id()).isEqualTo(lastGiftBoxId - 5);
         }
-    }
-
-    private boolean isValidUUID(String value) {
-        final Pattern uuidPattern =
-            Pattern.compile(
-                "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
-        return value != null && uuidPattern.matcher(value).matches();
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#214 

## 🪐 작업 내용
- 웹용 선물박스 열기 API의 path variable로 id와 uuid 둘 다 사용 가능하도록 코드를 수정하였습니다.
  - String이 UUID인지 검증하는 validator 클래스를 만들었습니다. (기존에 GiftBoxServiceTest.java에 있던 private 함수를 util 클래스로 이동)
- docker-compose로 컨테이너를 올릴 때 `'version' is obsolete` 라는 경고가 떠서 docker-compose.yml에서 버전명을 제거하였습니다.

## 📚 Reference
- docker-compose 경고: https://velog.io/@devmini1203/docker-compose-warn0000-version-is-obsolete-%EA%B2%BD%EA%B3%A0

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [ ] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
