### PR TITLE
fix: CorsConfig allowedMethods 수정

### DIFF
--- a/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
@@ -10,7 +10,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedMethods("*")
+            .allowedMethods("HEAD", "GET", "OPTIONS")
             .allowedOrigins("https://packyforyou.com", "https://dev.packyforyou.com");
     }
 }

--- a/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
@@ -10,7 +10,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedMethods("GET")
+            .allowedMethods("*")
             .allowedOrigins("https://packyforyou.com", "https://dev.packyforyou.com");
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#214 

## 🪐 작업 내용
> Access to fetch at 'https://{버킷 주소}/admin/design/Box_motion/arr/Box_motion_arr_1.json' from origin 'https://{개발용 웹 사이트}' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.

- 문제 상황: S3, CloudFront 설정을 수정했으나 해결되지 않음
- 해결 과정: preflight 요청 관련 문제일 수 있을 것 같아 HEAD, OPTIONS 메서드를 허용하도록 코드를 변경

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
