### PR TITLE
fix: 웹에서 이미 열린 선물박스 접근 시 예외 처리 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -66,7 +66,7 @@ public class GiftBoxController {
         """)
     @ApiErrorCodeExamples({
         ErrorCode.GIFTBOX_NOT_FOUND,
-        ErrorCode.GIFTBOX_ALREADY_OPENDED,
+        ErrorCode.GIFTBOX_ALREADY_OPENED,
         ErrorCode.GIFTBOX_ACCESS_DENIED,
         ErrorCode.GIFTBOX_ALREADY_DELETED
     })

--- a/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
+++ b/packy-api/src/main/java/com/dilly/gift/api/GiftBoxController.java
@@ -79,10 +79,10 @@ public class GiftBoxController {
 
     @Operation(summary = "(WEB) 선물박스 열기", description = """
         선물이 없을 경우 응답에서 gift 객체가 제외됩니다. <br>
-        선물박스를 보낸 뒤 7일이 지나면 선물박스를 열 수 없습니다. <br>
         """)
     @ApiErrorCodeExamples({
         ErrorCode.GIFTBOX_NOT_FOUND,
+        ErrorCode.GIFTBOX_ALREADY_OPENED,
         ErrorCode.GIFTBOX_ALREADY_DELETED,
         ErrorCode.GIFTBOX_URL_EXPIRED,
         ErrorCode.INVALID_INPUT_VALUE

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -185,6 +185,13 @@ public class GiftBoxService {
         } else {
             try {
                 giftBox = giftBoxReader.findById(Long.parseLong(giftBoxId));
+
+                List<Receiver> receiver = receiverReader.findByGiftBox(giftBox);
+
+                boolean hasReceiver = !receiver.isEmpty();
+                if (hasReceiver) {
+                    throw new GiftBoxAlreadyOpenedException();
+                }
             } catch (NumberFormatException e) {
                 throw new UnsupportedException(ErrorCode.INVALID_INPUT_VALUE);
             }

--- a/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
+++ b/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class TokenProvider {
+
 	private static final String AUTHORITIES_KEY = "auth";
 	private static final String BEARER_TYPE = "Bearer";
 	private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 30;            // 30분

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -67,7 +67,7 @@ public enum ErrorCode {
     // GiftBox
     BOX_NOT_FOUND(HttpStatus.NOT_FOUND, "선물 박스를 찾을 수 없습니다."),
     ENVELOPE_NOT_FOUND(HttpStatus.NOT_FOUND, "편지 봉투를 찾을 수 없습니다."),
-    GIFTBOX_ALREADY_OPENDED(HttpStatus.CONFLICT, "이미 열린 선물입니다."),
+    GIFTBOX_ALREADY_OPENED(HttpStatus.CONFLICT, "이미 열린 선물입니다."),
     GIFTBOX_ACCESS_DENIED(HttpStatus.FORBIDDEN, "선물박스에 접근할 수 없습니다."),
     GIFTBOX_ALREADY_DELETED(HttpStatus.NOT_FOUND, "이미 삭제된 선물박스입니다."),
     GIFTBOX_URL_EXPIRED(HttpStatus.BAD_REQUEST, "URL이 만료되었습니다."),

--- a/packy-common/src/main/java/com/dilly/exception/GiftBoxAlreadyOpenedException.java
+++ b/packy-common/src/main/java/com/dilly/exception/GiftBoxAlreadyOpenedException.java
@@ -3,6 +3,6 @@ package com.dilly.exception;
 public class GiftBoxAlreadyOpenedException extends BusinessException {
 
     public GiftBoxAlreadyOpenedException() {
-        super(ErrorCode.GIFTBOX_ALREADY_OPENDED);
+        super(ErrorCode.GIFTBOX_ALREADY_OPENED);
     }
 }

--- a/packy-domain/src/main/java/com/dilly/member/domain/Member.java
+++ b/packy-domain/src/main/java/com/dilly/member/domain/Member.java
@@ -31,6 +31,7 @@ public class Member extends BaseTimeEntity {
 	private Provider provider;
 
 	@Enumerated(EnumType.STRING)
+	@Builder.Default
 	private Role role = Role.ROLE_USER;
 
 	private String nickname;
@@ -43,6 +44,7 @@ public class Member extends BaseTimeEntity {
 	Boolean marketingAgreement;
 
 	@Enumerated(EnumType.STRING)
+	@Builder.Default
 	Status status = Status.REGISTERED;
 
 	@Builder


### PR DESCRIPTION
## 🛰️ Issue Number
#214 

## 🪐 작업 내용
- 웹에서 이미 열린 선물박스에 접근하지 못하도록 예외 처리를 추가하였습니다.
- Swagger에서 API 테스트 시 403 에러가 발생하여 @Builder.Default를 사용하여 Member 엔티티의 초기값을 적용하도록 코드를 추가하였습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
