### PR TITLE
fix: 나중에 보내는 선물박스의 gift null check 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -302,7 +302,8 @@ public class GiftBoxService {
                     fileService.deleteFile(photo.getImgUrl());
                     photoWriter.delete(photo);
                 });
-                if (giftBox.getGift().getGiftType().equals(GiftType.PHOTO)) {
+                if (giftBox.getGift() != null && giftBox.getGift().getGiftType()
+                    .equals(GiftType.PHOTO)) {
                     fileService.deleteFile(giftBox.getGift().getGiftUrl());
                 }
                 giftBox.getGiftBoxStickers().forEach(giftBoxStickerWriter::delete);

--- a/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/GiftBox.java
+++ b/packy-domain/src/main/java/com/dilly/gift/domain/giftbox/GiftBox.java
@@ -64,6 +64,7 @@ public class GiftBox extends BaseTimeEntity {
 
     private String youtubeUrl;
 
+    // TODO: Optional로 수정
     @Embedded
     private Gift gift;
 


### PR DESCRIPTION
## 🛰️ Issue Number
#238 

## 🪐 작업 내용
- 나중에 보내는 선물박스의 gift null check를 추가했습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
