### PR TITLE
refactor: OAuth 관련 코드 리팩토링

### DIFF
--- a/.github/workflows/packy-cd-dev.yml
+++ b/.github/workflows/packy-cd-dev.yml
@@ -37,16 +37,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
 
-      - name: Gradle Caching
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-   
-
       - name: Build with Gradle & Upload Image to ECR
         run: ./gradlew -Pdev clean jib
 

--- a/.github/workflows/packy-cd-prod.yml
+++ b/.github/workflows/packy-cd-prod.yml
@@ -37,16 +37,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
 
-      - name: Gradle Caching
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-   
-
       - name: Build with Gradle & Upload Image to ECR
         run: ./gradlew -Pprod clean jib
 

--- a/.github/workflows/packy-ci.yml
+++ b/.github/workflows/packy-ci.yml
@@ -27,16 +27,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Gradle Caching
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-               
-
       - name: Run build with Gradle Wrapper
         run: ./gradlew clean build --parallel
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,6 @@ subprojects {
         // lombok
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
-
         testCompileOnly 'org.projectlombok:lombok'
         testAnnotationProcessor 'org.projectlombok:lombok'
 

--- a/packy-api/build.gradle
+++ b/packy-api/build.gradle
@@ -38,9 +38,6 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
-    // webflux (for WebClient)
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
     // json parser
     implementation 'com.google.code.gson:gson:2.8.9'
 
@@ -49,10 +46,6 @@ dependencies {
 
     // sentry
     implementation 'io.sentry:sentry-logback:7.3.0'
-
-    // apple login
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
-    implementation 'org.bouncycastle:bcpkix-jdk14:1.72'
 
     // junit
     testImplementation('org.junit-pioneer:junit-pioneer:2.2.0')
@@ -70,9 +63,9 @@ tasks.register('copySecret', Copy) {
 }
 
 if (project.hasProperty('dev')) {
-    apply from: project.file('profile-dev.gradle');
+    apply from: project.file('profile-dev.gradle')
 } else if (project.hasProperty('prod')) {
-    apply from: project.file('profile-prod.gradle');
+    apply from: project.file('profile-prod.gradle')
 }
 
 bootJar.enabled = true

--- a/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
+++ b/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
@@ -1,7 +1,7 @@
 package com.dilly.auth.api;
 
+import com.dilly.application.KakaoService;
 import com.dilly.auth.application.AuthService;
-import com.dilly.auth.application.KakaoService;
 import com.dilly.auth.dto.request.SignupRequest;
 import com.dilly.auth.dto.response.SignInResponse;
 import com.dilly.exception.ErrorCode;

--- a/packy-api/src/main/java/com/dilly/auth/application/strategy/AppleStrategy.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/strategy/AppleStrategy.java
@@ -1,16 +1,16 @@
 package com.dilly.auth.application.strategy;
 
+import com.dilly.application.AppleService;
 import com.dilly.auth.adaptor.AppleAccountReader;
 import com.dilly.auth.adaptor.AppleAccountWriter;
-import com.dilly.auth.application.AppleService;
 import com.dilly.auth.domain.AppleAccount;
 import com.dilly.auth.dto.request.SignupRequest;
-import com.dilly.auth.model.AppleAccountInfo;
-import com.dilly.auth.model.AppleToken;
 import com.dilly.member.adaptor.MemberWriter;
 import com.dilly.member.domain.Member;
 import com.dilly.member.domain.ProfileImage;
 import com.dilly.member.domain.Provider;
+import com.dilly.model.AppleAccountInfo;
+import com.dilly.model.AppleToken;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -53,8 +53,9 @@ public class AppleStrategy implements AuthStrategy {
     @Override
     public void withdraw(Member member) {
         AppleAccount appleAccount = appleAccountReader.findByMember(member);
+        String appleRefreshToken = appleAccount.getRefreshToken();
 
-        appleService.revokeAppleAccount(appleAccount);
+        appleService.revokeAppleAccount(appleRefreshToken);
         appleAccountWriter.delete(appleAccount);
     }
 }

--- a/packy-api/src/main/java/com/dilly/auth/application/strategy/KakaoStrategy.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/strategy/KakaoStrategy.java
@@ -1,15 +1,15 @@
 package com.dilly.auth.application.strategy;
 
+import com.dilly.application.KakaoService;
 import com.dilly.auth.adaptor.KakaoAccountReader;
 import com.dilly.auth.adaptor.KakaoAccountWriter;
-import com.dilly.auth.application.KakaoService;
 import com.dilly.auth.domain.KakaoAccount;
 import com.dilly.auth.dto.request.SignupRequest;
-import com.dilly.auth.model.KakaoResource;
 import com.dilly.member.adaptor.MemberWriter;
 import com.dilly.member.domain.Member;
 import com.dilly.member.domain.ProfileImage;
 import com.dilly.member.domain.Provider;
+import com.dilly.model.KakaoResource;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -31,7 +31,12 @@ public class KakaoStrategy implements AuthStrategy {
         kakaoAccountReader.isKakaoAccountPresent(kakaoResource.getId());
 
         Member member = memberWriter.save(signupRequest.toMember(Provider.KAKAO, profileImage));
-        kakaoAccountWriter.save(kakaoResource.toMember(member));
+        // TODO: Mapper를 다른 클래스로 분리
+        KakaoAccount kakaoAccount = KakaoAccount.builder()
+            .id(kakaoResource.getId())
+            .member(member)
+            .build();
+        kakaoAccountWriter.save(kakaoAccount);
 
         return member;
     }
@@ -47,7 +52,7 @@ public class KakaoStrategy implements AuthStrategy {
     public void withdraw(Member member) {
         KakaoAccount kakaoAccount = kakaoAccountReader.findByMember(member);
 
-        kakaoService.unlinkKakaoAccount(kakaoAccount);
+        kakaoService.unlinkKakaoAccount(kakaoAccount.getId());
         kakaoAccountWriter.delete(kakaoAccount);
     }
 }

--- a/packy-api/src/main/java/com/dilly/global/config/TimeConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package com.dilly.global.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/packy-api/src/main/java/com/dilly/jwt/JwtService.java
+++ b/packy-api/src/main/java/com/dilly/jwt/JwtService.java
@@ -43,6 +43,7 @@ public class JwtService {
 	}
 
 	public JwtResponse reissueJwt(JwtRequest jwtRequest) {
+		// TODO: 슬랙 알림 안 오도록 변경
 		if (!tokenProvider.validateToken(jwtRequest.refreshToken())) {
 			throw new AuthorizationFailedException(ErrorCode.INVALID_REFRESH_TOKEN);
 		}

--- a/packy-api/src/test/java/com/dilly/auth/application/AuthServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/auth/application/AuthServiceTest.java
@@ -23,7 +23,7 @@ class AuthServiceTest extends IntegrationTestSupport {
         .marketingAgreement(true)
         .build();
 
-    @DisplayName("올바르지 않은 Provider Type을 요청할 경우 예외가 발생한다.")
+    @DisplayName("올바르지 않은 Provider Type으로 회원가입을 요청할 경우 예외가 발생한다.")
     @Test
     void throwExceptionWithWrongProviderType() {
         // given

--- a/packy-api/src/test/java/com/dilly/auth/application/AuthServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/auth/application/AuthServiceTest.java
@@ -3,16 +3,29 @@ package com.dilly.auth.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.dilly.MemberEnumFixture;
 import com.dilly.auth.dto.request.SignupRequest;
+import com.dilly.auth.dto.response.SignInResponse;
 import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.gift.domain.giftbox.admin.AdminType;
 import com.dilly.global.IntegrationTestSupport;
+import com.dilly.global.WithCustomMockUser;
+import com.dilly.jwt.RefreshToken;
 import com.dilly.jwt.dto.JwtResponse;
 import com.dilly.member.domain.Member;
+import com.dilly.member.domain.Status;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 
 class AuthServiceTest extends IntegrationTestSupport {
+
+    private Member NORMAL_MEMBER;
+    private final String MEMBER_ID = "1";
 
     private final String TEST_ACCESS_TOKEN = "test";
     private final SignupRequest TEST_SIGNUP_REQUEST = SignupRequest.builder()
@@ -22,6 +35,12 @@ class AuthServiceTest extends IntegrationTestSupport {
         .pushNotification(true)
         .marketingAgreement(true)
         .build();
+
+    @BeforeEach
+    void setUp() {
+        Long memberId = Long.parseLong(MEMBER_ID);
+        NORMAL_MEMBER = memberWriter.save(MemberEnumFixture.NORMAL_MEMBER.createMember(memberId));
+    }
 
     @DisplayName("올바르지 않은 Provider Type으로 회원가입을 요청할 경우 예외가 발생한다.")
     @Test
@@ -60,5 +79,42 @@ class AuthServiceTest extends IntegrationTestSupport {
         // then
         assertThat(receiverAfter).isEqualTo(receiverBefore + 1);
         assertThat(giftBoxCount).isEqualTo(1);
+    }
+
+    @DisplayName("로그인 시나리오")
+    @TestFactory
+    Collection<DynamicTest> signIn() {
+        final String PROVIDER = "test";
+
+        return List.of(
+            DynamicTest.dynamicTest("회원이 아니라면 NOT_REGISTERED를 반환한다.", () -> {
+                // given // when
+                SignInResponse signInResponse = authService.signIn(PROVIDER, TEST_ACCESS_TOKEN);
+
+                // then
+                assertThat(signInResponse.status()).isEqualTo(Status.NOT_REGISTERED);
+            })
+            // TODO: 테스트 provider로 회원인 경우 테스트 불가
+        );
+    }
+
+    @DisplayName("회원탈퇴 시 Refresh token을 hard delete한다.")
+    @Test
+    @WithCustomMockUser(id = MEMBER_ID)
+    void withdraw() {
+        // given
+        jwtWriter.save(RefreshToken.builder()
+            .member(NORMAL_MEMBER)
+            .refreshToken("test")
+            .build());
+
+        Long refreshTokenBefore = jwtReader.count();
+
+        // when
+        authService.withdraw();
+        Long refreshTokenAfter = jwtReader.count();
+
+        // then
+        assertThat(refreshTokenAfter).isEqualTo(refreshTokenBefore - 1);
     }
 }

--- a/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/gift/application/GiftBoxServiceTest.java
@@ -437,7 +437,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
         @DisplayName("선물박스를 보낸 사람이라면")
         class IfSender {
 
-            @DisplayName("전송 완료된 선물 박스는")
+            @DisplayName("전송 완료된 선물 박스 시나리오")
             @TestFactory
             Collection<DynamicTest> deliveredGiftBox() {
                 // given
@@ -473,7 +473,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
                 );
             }
 
-            @DisplayName("전송 대기 중인 선물박스라면")
+            @DisplayName("전송 대기 중인 선물박스 시나리오")
             @TestFactory
             Collection<DynamicTest> waitingGiftBox() {
                 // given
@@ -522,7 +522,7 @@ class GiftBoxServiceTest extends IntegrationTestSupport {
         // 선물박스를 받았다는 정보를 soft delete한다.
         // 받은 사람은 선물박스에 다시 접근할 수 없다
         // 보낸 사람은 선물박스에  다시 접근할 수 있다
-        @DisplayName("선물박스를 받은 사람이라면")
+        @DisplayName("선물박스를 받은 사람 시나리오")
         @TestFactory
         Collection<DynamicTest> ifReceiver() {
             // given

--- a/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
@@ -25,6 +25,10 @@ import com.dilly.member.adaptor.MemberWriter;
 import com.dilly.member.adaptor.ProfileImageReader;
 import com.dilly.member.application.MyPageService;
 import jakarta.transaction.Transactional;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -46,6 +50,9 @@ public abstract class IntegrationTestSupport {
 
     @MockBean
     protected FileService fileService;
+
+    @MockBean
+    protected Clock clock;
 
     @Autowired
     protected AdminService adminService;
@@ -118,6 +125,13 @@ public abstract class IntegrationTestSupport {
 
     @Autowired
     protected WithCustomMockUserSecurityContextFactory withCustomMockUserSecurityContextFactory;
+
+    @BeforeEach
+    protected void setClock() {
+        final Instant now = Instant.now();
+        given(clock.instant()).willReturn(now);
+        given(clock.getZone()).willReturn(ZoneId.systemDefault());
+    }
 
     // Dynamic test에서 MockUser 다르게 설정할 때 사용
     protected void createSecurityContextWithMockUser(String memberId) {

--- a/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
@@ -1,5 +1,7 @@
 package com.dilly.global;
 
+import static org.mockito.BDDMockito.given;
+
 import com.dilly.admin.adaptor.AdminGiftBoxReader;
 import com.dilly.admin.adaptor.SettingReader;
 import com.dilly.admin.application.AdminService;
@@ -19,7 +21,7 @@ import com.dilly.gift.adaptor.PhotoWriter;
 import com.dilly.gift.adaptor.ReceiverReader;
 import com.dilly.gift.adaptor.ReceiverWriter;
 import com.dilly.gift.application.GiftBoxService;
-import com.dilly.jwt.adaptor.JwtReader;
+import com.dilly.jwt.TokenProvider;
 import com.dilly.member.adaptor.MemberReader;
 import com.dilly.member.adaptor.MemberWriter;
 import com.dilly.member.adaptor.ProfileImageReader;
@@ -65,6 +67,9 @@ public abstract class IntegrationTestSupport {
 
     @Autowired
     protected MyPageService myPageService;
+
+    @Autowired
+    protected TokenProvider tokenProvider;
 
     @Autowired
     protected ProfileImageReader profileImageReader;
@@ -119,9 +124,6 @@ public abstract class IntegrationTestSupport {
 
     @Autowired
     protected AdminGiftBoxReader adminGiftBoxReader;
-
-    @Autowired
-    protected JwtReader jwtReader;
 
     @Autowired
     protected WithCustomMockUserSecurityContextFactory withCustomMockUserSecurityContextFactory;

--- a/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
@@ -21,7 +21,10 @@ import com.dilly.gift.adaptor.PhotoWriter;
 import com.dilly.gift.adaptor.ReceiverReader;
 import com.dilly.gift.adaptor.ReceiverWriter;
 import com.dilly.gift.application.GiftBoxService;
+import com.dilly.jwt.JwtService;
 import com.dilly.jwt.TokenProvider;
+import com.dilly.jwt.adaptor.JwtReader;
+import com.dilly.jwt.adaptor.JwtWriter;
 import com.dilly.member.adaptor.MemberReader;
 import com.dilly.member.adaptor.MemberWriter;
 import com.dilly.member.adaptor.ProfileImageReader;
@@ -61,6 +64,9 @@ public abstract class IntegrationTestSupport {
 
     @Autowired
     protected AuthService authService;
+
+    @Autowired
+    protected JwtService jwtService;
 
     @Autowired
     protected GiftBoxService giftBoxService;
@@ -124,6 +130,12 @@ public abstract class IntegrationTestSupport {
 
     @Autowired
     protected AdminGiftBoxReader adminGiftBoxReader;
+
+    @Autowired
+    protected JwtReader jwtReader;
+
+    @Autowired
+    protected JwtWriter jwtWriter;
 
     @Autowired
     protected WithCustomMockUserSecurityContextFactory withCustomMockUserSecurityContextFactory;

--- a/packy-api/src/test/java/com/dilly/jwt/JwtServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/jwt/JwtServiceTest.java
@@ -1,0 +1,50 @@
+package com.dilly.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dilly.MemberEnumFixture;
+import com.dilly.global.IntegrationTestSupport;
+import com.dilly.jwt.dto.JwtResponse;
+import com.dilly.member.domain.Member;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+class JwtServiceTest extends IntegrationTestSupport {
+
+    @DisplayName("JWT 발급 시나리오")
+    @TestFactory
+    Collection<DynamicTest> issueJwt() {
+        // given
+        Member member = MemberEnumFixture.NORMAL_MEMBER.createMember(1L);
+
+        return List.of(
+            DynamicTest.dynamicTest("회원가입 시 Refresh token을 저장한다.", () -> {
+                // given
+                Long refreshTokenBefore = jwtReader.count();
+
+                // when
+                jwtService.issueJwt(member);
+                Long refreshTokenAfter = jwtReader.count();
+
+                // then
+                assertThat(refreshTokenAfter).isEqualTo(refreshTokenBefore + 1);
+            }),
+            DynamicTest.dynamicTest("로그인 시 Refresh token을 업데이트한다.", () -> {
+                // given
+                Long refreshTokenBefore = jwtReader.count();
+
+                // when
+                JwtResponse jwtResponse = jwtService.issueJwt(member);
+                Long refreshTokenAfter = jwtReader.count();
+                RefreshToken refreshToken = jwtReader.findByMember(member);
+
+                // then
+                assertThat(refreshTokenAfter).isEqualTo(refreshTokenBefore);
+                assertThat(refreshToken.getRefreshToken()).isEqualTo(jwtResponse.refreshToken());
+            })
+        );
+    }
+}

--- a/packy-api/src/test/java/com/dilly/jwt/TokenProviderTest.java
+++ b/packy-api/src/test/java/com/dilly/jwt/TokenProviderTest.java
@@ -1,0 +1,76 @@
+package com.dilly.jwt;
+
+import static com.dilly.MemberEnumFixture.NORMAL_MEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dilly.global.IntegrationTestSupport;
+import com.dilly.jwt.dto.JwtResponse;
+import com.dilly.member.domain.Member;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+
+class TokenProviderTest extends IntegrationTestSupport {
+
+    private Member member;
+    private final Long memberId = 1L;
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private Key key;
+
+    @BeforeEach
+    void setUp() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+
+        // given
+        member = NORMAL_MEMBER.createMember(memberId);
+    }
+
+    @DisplayName("Access, Refresh 토큰을 생성하여 반환한다.")
+    @Test
+    void generateJwt() {
+        // given
+        String bearerType = "Bearer";
+        long accessTokenExpireTime = 1000L * 60 * 30;
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        long nowMillis = now.atZone(Clock.systemDefaultZone().getZone()).toInstant().toEpochMilli();
+        Date accessTokenExpiresIn = new Date(nowMillis + (accessTokenExpireTime));
+
+        String expectedAccessToken = Jwts.builder()
+            .setSubject(member.getId().toString())
+            .claim("socialLoginType", member.getProvider())
+            .claim("nickname", member.getNickname())
+            .claim("auth", member.getRole())
+            .setExpiration(accessTokenExpiresIn)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+
+        String expectedRefreshToken = Jwts.builder()
+            .setSubject(member.getId().toString())
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+
+        // when
+        JwtResponse jwtResponse = tokenProvider.generateJwt(member);
+
+        // then
+        assertThat(jwtResponse.id()).isEqualTo(memberId);
+        assertThat(jwtResponse.grantType()).isEqualTo(bearerType);
+        assertThat(jwtResponse.accessToken()).isEqualTo(expectedAccessToken);
+        assertThat(jwtResponse.refreshToken()).isEqualTo(expectedRefreshToken);
+        assertThat(jwtResponse.accessTokenExpiresIn()).isEqualTo(accessTokenExpiresIn.getTime());
+    }
+}

--- a/packy-domain/src/main/java/com/dilly/jwt/adaptor/JwtReader.java
+++ b/packy-domain/src/main/java/com/dilly/jwt/adaptor/JwtReader.java
@@ -15,4 +15,8 @@ public class JwtReader {
 	public RefreshToken findByMember(Member member) {
 		return refreshTokenRepository.findByMember(member);
 	}
+
+	public Long count() {
+		return refreshTokenRepository.count();
+	}
 }

--- a/packy-infra/build.gradle
+++ b/packy-infra/build.gradle
@@ -25,6 +25,18 @@ dependencies {
     implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
     implementation 'com.google.apis:google-api-services-youtube:v3-rev20230816-2.0.0'
     implementation 'com.google.http-client:google-http-client-jackson2:1.43.1'
+
+    // jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+    // apple login
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
+    implementation 'org.bouncycastle:bcpkix-jdk14:1.72'
+
+    // webflux (for WebClient)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 test {

--- a/packy-infra/src/main/java/com/dilly/application/AppleService.java
+++ b/packy-infra/src/main/java/com/dilly/application/AppleService.java
@@ -1,13 +1,12 @@
-package com.dilly.auth.application;
+package com.dilly.application;
 
-import com.dilly.auth.domain.AppleAccount;
-import com.dilly.auth.model.AppleAccountInfo;
-import com.dilly.auth.model.ApplePublicKey;
-import com.dilly.auth.model.ApplePublicKey.Key;
-import com.dilly.auth.model.AppleToken;
 import com.dilly.exception.ErrorCode;
 import com.dilly.exception.internalserver.AppleServerException;
 import com.dilly.exception.internalserver.InternalServerException;
+import com.dilly.model.AppleAccountInfo;
+import com.dilly.model.ApplePublicKey;
+import com.dilly.model.ApplePublicKey.Key;
+import com.dilly.model.AppleToken;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
@@ -171,10 +170,8 @@ public class AppleService {
 		}
 	}
 
-	public void revokeAppleAccount(AppleAccount appleAccount) {
+	public void revokeAppleAccount(String appleRefreshToken) {
 		try {
-			String appleRefreshToken = appleAccount.getRefreshToken();
-
 			WebClient webClient = WebClient.builder()
 				.baseUrl(appleRevokeUri)
 				.build();

--- a/packy-infra/src/main/java/com/dilly/application/KakaoService.java
+++ b/packy-infra/src/main/java/com/dilly/application/KakaoService.java
@@ -59,7 +59,7 @@ public class KakaoService {
 	}
 
 	public String getKakaoAccessToken(String code) {
-		String access_Token = "";
+		String accessToken = "";
 
 		try {
 			URL url = new URL(KakaoService.this.kakaoTokenUri);
@@ -80,20 +80,22 @@ public class KakaoService {
 
 			BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
 			String line = "";
-			String result = "";
-
+			StringBuilder stringBuilder = new StringBuilder();
 			while ((line = br.readLine()) != null) {
-				result += line;
+				stringBuilder.append(line);
 			}
+			String result = stringBuilder.toString();
 
-			access_Token = ((JsonObject)JsonParser.parseString(result)).get("access_token").getAsString();
+			accessToken = ((JsonObject) JsonParser.parseString(result)).get(
+					"access_token")
+				.getAsString();
 			br.close();
 			bw.close();
 		} catch (IOException e) {
 			log.error("IOException", e);
 		}
 
-		return access_Token;
+		return accessToken;
 	}
 
     public void unlinkKakaoAccount(String kakaoAccountId) {

--- a/packy-infra/src/main/java/com/dilly/application/KakaoService.java
+++ b/packy-infra/src/main/java/com/dilly/application/KakaoService.java
@@ -1,9 +1,8 @@
-package com.dilly.auth.application;
+package com.dilly.application;
 
-import com.dilly.auth.domain.KakaoAccount;
-import com.dilly.auth.model.KakaoResource;
 import com.dilly.exception.ErrorCode;
 import com.dilly.exception.internalserver.InternalServerException;
+import com.dilly.model.KakaoResource;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.BufferedReader;
@@ -97,7 +96,7 @@ public class KakaoService {
 		return access_Token;
 	}
 
-	public void unlinkKakaoAccount(KakaoAccount kakaoAccount) {
+    public void unlinkKakaoAccount(String kakaoAccountId) {
 		WebClient webClient = WebClient.builder()
 			.baseUrl(kakaoUnlinkUri)
 			.defaultHeader(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
@@ -106,7 +105,7 @@ public class KakaoService {
 
 		MultiValueMap<String, String> bodyData = new LinkedMultiValueMap<>();
 		bodyData.add("target_id_type", "user_id");
-		bodyData.add("target_id", kakaoAccount.getId());
+        bodyData.add("target_id", kakaoAccountId);
 
 		try {
 			webClient.post()

--- a/packy-infra/src/main/java/com/dilly/model/AppleAccountInfo.java
+++ b/packy-infra/src/main/java/com/dilly/model/AppleAccountInfo.java
@@ -1,6 +1,6 @@
-package com.dilly.auth.model;
+package com.dilly.model;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;

--- a/packy-infra/src/main/java/com/dilly/model/ApplePublicKey.java
+++ b/packy-infra/src/main/java/com/dilly/model/ApplePublicKey.java
@@ -1,8 +1,7 @@
-package com.dilly.auth.model;
+package com.dilly.model;
 
 import java.util.ArrayList;
 import java.util.Optional;
-
 import lombok.Getter;
 import lombok.ToString;
 

--- a/packy-infra/src/main/java/com/dilly/model/AppleToken.java
+++ b/packy-infra/src/main/java/com/dilly/model/AppleToken.java
@@ -1,6 +1,6 @@
-package com.dilly.auth.model;
+package com.dilly.model;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;

--- a/packy-infra/src/main/java/com/dilly/model/KakaoResource.java
+++ b/packy-infra/src/main/java/com/dilly/model/KakaoResource.java
@@ -1,8 +1,7 @@
-package com.dilly.auth.model;
+package com.dilly.model;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
-import com.dilly.member.domain.Member;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
@@ -11,17 +10,10 @@ import lombok.Getter;
 public class KakaoResource {
 
 	private String id;
-	private KakaoAccount kakao_account;
-
-    public com.dilly.auth.domain.KakaoAccount toMember(Member member) {
-        return com.dilly.auth.domain.KakaoAccount.builder()
-			.id(id)
-			.member(member)
-			.build();
-	}
+	private KakaoAccountInfo kakao_account;
 
 	@JsonInclude(NON_NULL)
-	public static class KakaoAccount {
+	public static class KakaoAccountInfo {
 
 		private Profile profile;
 		private String email;

--- a/packy-infra/src/main/java/com/dilly/model/KakaoResource.java
+++ b/packy-infra/src/main/java/com/dilly/model/KakaoResource.java
@@ -3,14 +3,17 @@ package com.dilly.model;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 
 @Getter
 @JsonInclude(NON_NULL)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoResource {
 
 	private String id;
-	private KakaoAccountInfo kakao_account;
+	private KakaoAccountInfo kakaoAccount;
 
 	@JsonInclude(NON_NULL)
 	public static class KakaoAccountInfo {
@@ -20,10 +23,11 @@ public class KakaoResource {
 		private String gender;
 
 		@JsonInclude(NON_NULL)
+		@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 		public static class Profile {
 
 			private String nickname;
-			private String profile_image_url;
+			private String profileImageUrl;
 		}
 	}
 

--- a/packy-support/src/main/java/com/dilly/logging/LogAspect.java
+++ b/packy-support/src/main/java/com/dilly/logging/LogAspect.java
@@ -4,7 +4,7 @@ import com.dilly.member.adaptor.MemberReader;
 import com.dilly.member.domain.Status;
 import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
-import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +26,7 @@ public class LogAspect {
     @Pointcut("execution(* com.dilly.auth..AuthController.signUp(..))")
     public void signUp() {}
 
-    @After("signUp()")
+    @AfterReturning("signUp()")
     public void countMember() {
         String title = "패키에 유저가 들어왔어요!";
         HashMap<String, String> data = new HashMap<>();

--- a/packy-support/src/main/java/com/dilly/logging/SlackAspect.java
+++ b/packy-support/src/main/java/com/dilly/logging/SlackAspect.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 @Profile("prod")
 @Component
 @RequiredArgsConstructor
-public class LogAspect {
+public class SlackAspect {
 
     private final SlackService slackService;
     private final MemberReader memberReader;


### PR DESCRIPTION
## 🛰️ Issue Number
#54 #60

## 🪐 작업 내용
- 카카오, 애플 외부 API 연동 클래스(KakaoService, AppleService)를 api 모듈에서 infra 모듈로 분리하였습니다.
- 테스트 코드를 작성하였습니다.
  - JWT 생성, JWT 발급, 로그인, 회원탈퇴
- 기타 사소한 작업을 함께 진행하였습니다.
  - Github Actions의 `Setup Gradle` 작업 시 캐싱이 이미 진행되므로 추가적인 Gradle 캐싱 스크립트를 제거하였습니다.
  - LogAspect 클래스가 로깅보다는 슬랙 알림 전송과 관련되어 있어 SlackAspect로 클래스 이름을 변경하였습니다.
  -  SlackAspect의 countMember 메소드가 회원가입 성공 시에만 동작하도록 어노테이션을 @AfterReturning으로 변경하였습니다. (기존에는 성공 유무와 관련없이 실행됐었음)

## 📚 Reference
- https://medium.com/@jojiapp/junit-localdatetime-now-mocking-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0-fb24119976f1

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
