### PR TITLE
deploy: 배포 시에도 CI 스크립트가 실행되도록 트리거 변경

### DIFF
--- a/.github/workflows/packy-ci.yml
+++ b/.github/workflows/packy-ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - develop
+  push:
+    branches:
+      - main
+      - develop
 
 permissions:
   contents: read


### PR DESCRIPTION
## 🛰️ Issue Number
#248 

## 🪐 작업 내용
- CI 스크립트 트리거 조건으로 main, develop 브랜치에 푸시가 발생했을 때를 추가하였습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
