### PR TITLE
fix: allowedHeaders 와일드 카드 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
@@ -10,6 +10,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
+            .allowedHeaders("*")
             .allowedMethods("HEAD", "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE")
             .allowedOrigins("https://packyforyou.com", "https://dev.packyforyou.com");
     }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 웹 프론트엔드에서 발생하는 CORS 문제를 해결하기 위해 allowedHeaders를 와일드 카드로 추가했습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
