### PR TITLE
fix: preflight 결과 캐시 저장을 위한 CORS maxAge 설정 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
@@ -12,6 +12,7 @@ public class CorsConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
             .allowedHeaders("*")
             .allowedMethods("HEAD", "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE")
-            .allowedOrigins("https://packyforyou.com", "https://dev.packyforyou.com");
+            .allowedOrigins("https://packyforyou.com", "https://dev.packyforyou.com")
+            .maxAge(3600);
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- CORS 설정에 maxAge 설정을 GPT 답변을 참고하여 3600초로 추가하였습니다.
<img width="760" alt="image" src="https://github.com/user-attachments/assets/0fb23ddd-9404-4629-a1be-f254a4df5e95">

## 📚 Reference
- https://hjsdev.tistory.com/entry/Spring-Security-CORS-%EC%9D%B4%EC%8A%88-%ED%95%B4%EA%B2%B0-Preflight-403-Invalid-CORS-request

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
