### PR TITLE
fix: CORS allowedOrigins를 와일드카드로 변경

### DIFF
--- a/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
@@ -12,8 +12,7 @@ public class CorsConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
             .allowedHeaders("*")
             .allowedMethods("HEAD", "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE")
-            .allowedOrigins("localhost:3000", "https://packyforyou.com",
-                "https://dev.packyforyou.com")
+            .allowedOrigins("*")
             .maxAge(3600);
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- CORS 설정에서 allowedOrigins를 와일드카드로 변경하였습니다

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
