### PR TITLE
fix: CORS allowedOrigins에 API 서버 도메인 추가

### DIFF
--- a/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
@@ -12,7 +12,8 @@ public class CorsConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
             .allowedHeaders("*")
             .allowedMethods("HEAD", "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE")
-            .allowedOrigins("*")
+            .allowedOrigins("https://packyforyou.com", "https://dev.packyforyou.com",
+                "https://dev.packyforyou.shop")
             .maxAge(3600);
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 프론트엔드 프록시 서버에서 발생하는 CORS 문제를 해결하기 위해 allowedOrigins에 API 서버 도메인을 추가하였습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
