### PR TITLE
fix: CORS 디버깅을 위한 RequestLoggingFilter 실행 순서 변경

### DIFF
--- a/packy-api/src/main/java/com/dilly/global/RequestLoggingFilter.java
+++ b/packy-api/src/main/java/com/dilly/global/RequestLoggingFilter.java
@@ -8,9 +8,13 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
+// TODO: CORS 에러 해결 후 삭제
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @Slf4j
 public class RequestLoggingFilter implements Filter {
 


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- CORS 정책을 통과하지 못했을 때 필터가 정상적으로 동작하지 않아 Request Origin이 null로 출력되는 것 같아 Ordered 어노테이션을 사용하여 RequestLoggingFilter가 가장 먼저 실행되도록 수정하였습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
