### PR TITLE
fix: 설정 파일에서 allowedOrigins 나열 형식 변경

### DIFF
--- a/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/CorsConfig.java
@@ -1,6 +1,5 @@
 package com.dilly.global.config;
 
-import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -12,14 +11,14 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class CorsConfig implements WebMvcConfigurer {
 
     @Value("${cors.allowedOrigins}")
-    private List<String> allowedOrigins;
+    private String[] allowedOrigins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
             .allowedHeaders("*")
             .allowedMethods("HEAD", "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE")
-            .allowedOrigins(allowedOrigins.toArray(new String[0]))
+            .allowedOrigins(allowedOrigins)
             .maxAge(3600);
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
application.yml에서 프로퍼티에 해당하는 값이 여러 개일 때 리스트 형식이 아니라 `,`를 구분자로 적어주어야 합니다.
더불어 allowedOrigins를 List가 아닌 Array 타입으로 받도록 수정하였습니다.

## 📚 Reference
- https://rutgo-letsgo.tistory.com/entry/Value%EC%99%80-ConfigurationProperties%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%B4-yaml-%ED%8C%8C%EC%9D%BC-%EB%A7%A4%ED%95%91%ED%95%98%EA%B8%B0

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
