### PR TITLE
feat: 카카오 로그인 연결 끊기 콜백 API 구현

### DIFF
--- a/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
+++ b/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
@@ -82,7 +82,7 @@ public class AuthController {
         return DataResponseDto.from(jwtService.reissueJwt(jwtRequest));
     }
 
-    @Operation(summary = "카카오 토큰으로 정보 조회", description = "서버에서 테스트용으로 사용하는 API입니다.")
+    @Operation(summary = "카카오 code로 token 정보 조회", description = "서버에서 테스트용으로 사용하는 API입니다.")
     @GetMapping("/token/kakao/{code}")
     public DataResponseDto<String> getKakaoAccessToken(@PathVariable(name = "code") String code) {
         return DataResponseDto.from(kakaoService.getKakaoAccessToken(code));

--- a/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
+++ b/packy-api/src/main/java/com/dilly/auth/api/AuthController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "OAuth 관련 API")
@@ -73,6 +74,15 @@ public class AuthController {
     @DeleteMapping("/withdraw")
     public DataResponseDto<String> withdraw() {
         return DataResponseDto.from(authService.withdraw());
+    }
+
+    @Operation(hidden = true)
+    @PostMapping("/withdraw/kakao")
+    public DataResponseDto<String> externalWithdraw(
+        @RequestHeader(name = "Authorization") String authorization,
+        @RequestParam(name = "user_id") String userId
+    ) {
+        return DataResponseDto.from(authService.externalWithdraw(authorization, userId));
     }
 
     @Operation(summary = "JWT 만료 시 재발급")

--- a/packy-api/src/main/java/com/dilly/auth/application/strategy/KakaoStrategy.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/strategy/KakaoStrategy.java
@@ -45,7 +45,7 @@ public class KakaoStrategy implements AuthStrategy {
     public Optional<Member> signIn(String providerAccessToken) {
         KakaoResource kakaoResource = kakaoService.getKaKaoAccount(providerAccessToken);
 
-        return kakaoAccountReader.getMemberById(kakaoResource.getId());
+        return kakaoAccountReader.findMemberById(kakaoResource.getId());
     }
 
     @Override

--- a/packy-api/src/main/java/com/dilly/global/config/SecurityConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
 						"/api/v1/auth/sign-up",
 						"/api/v1/auth/sign-in/**",
 						"/api/v1/auth/reissue",
+						"/api/v1/auth/withdraw/kakao",
 						"/api/v1/giftboxes/web/**",
 						"/api/v1/admin/branch"
 					).permitAll()

--- a/packy-domain/src/main/java/com/dilly/auth/adaptor/KakaoAccountReader.java
+++ b/packy-domain/src/main/java/com/dilly/auth/adaptor/KakaoAccountReader.java
@@ -20,7 +20,7 @@ public class KakaoAccountReader {
 		}
 	}
 
-	public Optional<Member> getMemberById(String id) {
+	public Optional<Member> findMemberById(String id) {
 		return kakaoAccountRepository.findById(id).map(KakaoAccount::getMember);
 	}
 


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 문제 상황: 패키 외부에서 카카오 연결 끊기를 한 뒤 다시 가입을 할 경우, 새로 가입이 되어야 합니다. 하지만 유저 정보가 DB에 존재하기 때문에 기존에 존재하는 유저라고 인식됩니다.
- 해결 방법: 카카오 로그인 API 콜백 기능을 사용하여 외부에서 카카오 연결을 끊을 경우 패키 API를 호출하여 DB의 정보를 삭제할 수 있는 API를 구현하였습니다.

## 📚 Reference
- https://developers.kakao.com/docs/latest/ko/kakaologin/prerequisite#unlink-callback
- https://developers.kakao.com/docs/latest/ko/kakaologin/callback#unlink

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
