### PR TITLE
fix: 탈퇴한 유저의 엔티티를 조회할 수 없도록 수정

### DIFF
--- a/db.vuerd.json
+++ b/db.vuerd.json
@@ -1,1823 +1,1909 @@
 {
-  "canvas": {
-    "version": "2.2.11",
+  "$schema": "https://raw.githubusercontent.com/dineug/erd-editor/main/json-schema/schema.json",
+  "version": "3.0.0",
+  "settings": {
     "width": 2500,
     "height": 2500,
-    "scrollTop": -179,
-    "scrollLeft": -1056,
+    "scrollTop": 0,
+    "scrollLeft": -562.9408,
     "zoomLevel": 1,
-    "show": {
-      "tableComment": true,
-      "columnComment": true,
-      "columnDataType": true,
-      "columnDefault": true,
-      "columnAutoIncrement": false,
-      "columnPrimaryKey": true,
-      "columnUnique": false,
-      "columnNotNull": true,
-      "relationship": true
-    },
-    "database": "MySQL",
+    "show": 431,
+    "database": 4,
     "databaseName": "Packy",
     "canvasType": "ERD",
-    "language": "GraphQL",
-    "tableCase": "pascalCase",
-    "columnCase": "camelCase",
-    "highlightTheme": "VS2015",
-    "bracketType": "none",
-    "setting": {
-      "relationshipDataTypeSync": true,
-      "relationshipOptimization": true,
-      "columnOrder": [
-        "columnName",
-        "columnDataType",
-        "columnNotNull",
-        "columnUnique",
-        "columnAutoIncrement",
-        "columnDefault",
-        "columnComment"
-      ]
-    },
-    "pluginSerializationMap": {}
+    "language": 1,
+    "tableNameCase": 4,
+    "columnNameCase": 2,
+    "bracketType": 1,
+    "relationshipDataTypeSync": true,
+    "relationshipOptimization": true,
+    "columnOrder": [
+      1,
+      2,
+      4,
+      8,
+      16,
+      32,
+      64
+    ],
+    "maxWidthComment": -1,
+    "ignoreSaveSettings": 0
   },
-  "table": {
-    "tables": [
-      {
+  "doc": {
+    "tableIds": [
+      "cd084f39-b9f7-4756-b509-21e56852208d",
+      "47966f5e-3bfe-4d71-91d6-e0003848c932",
+      "d3458f78-11f7-4dc8-9990-5282aade4396",
+      "67c2763b-46ef-4967-821e-206a52e3c32c",
+      "cb0209c5-3e02-4ac4-803c-33914ca2760d",
+      "fc991fdb-6c22-4ee1-b5a7-a62126aa55ff",
+      "f742a7da-0ab3-4353-a499-3ddc65b7b050",
+      "f7dd4680-c8f4-4b8a-b764-2d5c27742e1b",
+      "18ab0bbe-f634-4cc1-9573-66fa5a02b2a3",
+      "5994e084-05c5-44c6-8bc7-2b09bf6e82da",
+      "2bd92bc1-98cd-42d2-a70e-9e10942ad58f",
+      "a1ae4699-f461-4a59-8cd3-c45b476defef",
+      "d81ebbcf-fbc5-4e81-a7aa-13cf3c5cab39"
+    ],
+    "relationshipIds": [
+      "d6d41908-171e-4016-883a-8d62102243b0",
+      "55ea086f-38cc-4a04-92cb-5e2784228d1d",
+      "cb104e2f-38dc-4a19-9587-d63ee984b48b",
+      "ae457558-3496-4299-9870-a13872fc842d",
+      "7bea2bc5-9ba0-4e83-8287-245e37868355",
+      "c395606a-ed58-46b8-9e45-8d23df5b6fcc",
+      "60336fdd-2c1c-4517-8ef3-5f1caf9a0a4f",
+      "d36e79c8-1f2f-435b-aaa7-32138fc18c77",
+      "5d15a1c1-e33c-44c2-82f9-026a447bb5a5",
+      "5ed41cd3-9940-405e-bf80-43412bfa31c6",
+      "395dcfa0-1299-4777-9998-e6749384d061"
+    ],
+    "indexIds": [],
+    "memoIds": []
+  },
+  "collections": {
+    "tableEntities": {
+      "cd084f39-b9f7-4756-b509-21e56852208d": {
         "id": "cd084f39-b9f7-4756-b509-21e56852208d",
         "name": "Member",
         "comment": "유저",
-        "columns": [
-          {
-            "id": "e425f403-77ff-4332-acac-340f8cb521aa",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "c23828d4-9b90-490a-8ff1-34ccaf093c16",
-            "name": "nickname",
-            "comment": "6자 이내",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "1585a43a-06c5-4e3a-8a9f-09fd4f590bda",
-            "name": "loginType",
-            "comment": "admin, kakao, apple",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 109.43179321289062,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "0b2af273-08a4-4ac8-9fa2-e3a5ce8ca200",
-            "name": "pushNotification",
-            "comment": "",
-            "dataType": "TINYINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 91.98582458496094,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "e7d2c702-6d5b-48cb-bbf3-ad2d3460fb33",
-            "name": "profileImgId",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 67.96188354492188,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "aa26bea4-eef2-41d7-b1e9-41deb3fc0280",
-            "name": "isWithdrawal",
-            "comment": "탈퇴 여부",
-            "dataType": "TINYINT",
-            "default": "false",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 71.77084350585938,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "ec074e1a-fb92-45b7-a212-ab25fbfee79e",
-            "name": "marketingAgreement",
-            "comment": "",
-            "dataType": "TINYINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 117.29684448242188,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "53ac6902-c916-49a3-85aa-e39eac339f02",
-            "name": "createdAt",
-            "comment": "",
-            "dataType": "TIMESTAMP",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 68.2479248046875,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "b04d1899-b2fd-42f2-9123-44474dc793f9",
-            "name": "updatedAt",
-            "comment": "",
-            "dataType": "TIMESTAMP",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 68.2479248046875,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "e425f403-77ff-4332-acac-340f8cb521aa",
+          "c23828d4-9b90-490a-8ff1-34ccaf093c16",
+          "1585a43a-06c5-4e3a-8a9f-09fd4f590bda",
+          "0b2af273-08a4-4ac8-9fa2-e3a5ce8ca200",
+          "e7d2c702-6d5b-48cb-bbf3-ad2d3460fb33",
+          "aa26bea4-eef2-41d7-b1e9-41deb3fc0280",
+          "ec074e1a-fb92-45b7-a212-ab25fbfee79e",
+          "53ac6902-c916-49a3-85aa-e39eac339f02",
+          "b04d1899-b2fd-42f2-9123-44474dc793f9"
+        ],
+        "seqColumnIds": [
+          "e425f403-77ff-4332-acac-340f8cb521aa",
+          "c23828d4-9b90-490a-8ff1-34ccaf093c16",
+          "1585a43a-06c5-4e3a-8a9f-09fd4f590bda",
+          "0b2af273-08a4-4ac8-9fa2-e3a5ce8ca200",
+          "e7d2c702-6d5b-48cb-bbf3-ad2d3460fb33",
+          "aa26bea4-eef2-41d7-b1e9-41deb3fc0280",
+          "ec074e1a-fb92-45b7-a212-ab25fbfee79e",
+          "53ac6902-c916-49a3-85aa-e39eac339f02",
+          "b04d1899-b2fd-42f2-9123-44474dc793f9"
         ],
         "ui": {
-          "active": false,
-          "left": 564.4445,
-          "top": 34.4444,
+          "x": 156.4445,
+          "y": 486.1944,
           "zIndex": 12,
           "widthName": 60,
-          "widthComment": 60
+          "widthComment": 60,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811666315,
+          "createAt": 1724811425586
+        }
       },
-      {
+      "47966f5e-3bfe-4d71-91d6-e0003848c932": {
         "id": "47966f5e-3bfe-4d71-91d6-e0003848c932",
         "name": "GiftBox",
         "comment": "선물박스",
-        "columns": [
-          {
-            "id": "1f0095df-47d9-44ee-9992-1d5cf1102126",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "784b87f3-056e-4fa1-8864-bdd7f822caef",
-            "name": "senderId",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "8f314eec-c651-4b78-9f08-cb356f4e9519",
-            "name": "boxId",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "3f89ecfc-e228-4223-b30d-35558abba959",
-            "name": "letterId",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "4e16cace-2815-497f-b773-3e430d7ddc7b",
-            "name": "uuid",
-            "comment": "",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "ed996d2f-167f-4e07-a4cc-937ce1a22c29",
-            "name": "name",
-            "comment": "",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "40ca0888-f5d5-46bb-9e30-788f294a226b",
-            "name": "youtubeUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 63.06092834472656,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "a698d729-4e16-4df0-badf-9f400e69e257",
-            "name": "giftType",
-            "comment": "photo, link",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "d07f885a-1916-4dd1-a8f7-0a1a68f72a43",
-            "name": "giftMessage",
-            "comment": "",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 67.18190002441406,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "4f4705ac-1f0e-4620-8caa-f14ff960c132",
-            "name": "senderName",
-            "comment": "",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 70.67892456054688,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "65ce8cce-7b79-4ed6-8fa6-5836aef23d72",
-            "name": "receiverName",
-            "comment": "",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 77.42591857910156,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "8cc40b5b-dda7-4f0c-805f-c6ffeadf2424",
-            "name": "createdAt",
-            "comment": "",
-            "dataType": "TIMESTAMP",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 68.2479248046875,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "466b40e3-2e19-4587-ac32-ca1ab8a7a014",
-            "name": "updatedAt",
-            "comment": "수정 기능은 없지만 BaseTimeEntity를 사용하기 위해 추가",
-            "dataType": "TIMESTAMP",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 120,
-              "widthDataType": 68.2479248046875,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "1f0095df-47d9-44ee-9992-1d5cf1102126",
+          "784b87f3-056e-4fa1-8864-bdd7f822caef",
+          "8f314eec-c651-4b78-9f08-cb356f4e9519",
+          "3f89ecfc-e228-4223-b30d-35558abba959",
+          "4e16cace-2815-497f-b773-3e430d7ddc7b",
+          "ed996d2f-167f-4e07-a4cc-937ce1a22c29",
+          "40ca0888-f5d5-46bb-9e30-788f294a226b",
+          "a698d729-4e16-4df0-badf-9f400e69e257",
+          "d07f885a-1916-4dd1-a8f7-0a1a68f72a43",
+          "NuVu_F5fkC8RAD53CCGJF",
+          "4f4705ac-1f0e-4620-8caa-f14ff960c132",
+          "9LZjoShsSnl2XiV1V7y9G",
+          "gyhavOS-grCMzihxcxvyY",
+          "8cc40b5b-dda7-4f0c-805f-c6ffeadf2424",
+          "466b40e3-2e19-4587-ac32-ca1ab8a7a014"
+        ],
+        "seqColumnIds": [
+          "1f0095df-47d9-44ee-9992-1d5cf1102126",
+          "784b87f3-056e-4fa1-8864-bdd7f822caef",
+          "8f314eec-c651-4b78-9f08-cb356f4e9519",
+          "3f89ecfc-e228-4223-b30d-35558abba959",
+          "4e16cace-2815-497f-b773-3e430d7ddc7b",
+          "ed996d2f-167f-4e07-a4cc-937ce1a22c29",
+          "40ca0888-f5d5-46bb-9e30-788f294a226b",
+          "a698d729-4e16-4df0-badf-9f400e69e257",
+          "d07f885a-1916-4dd1-a8f7-0a1a68f72a43",
+          "NuVu_F5fkC8RAD53CCGJF",
+          "4f4705ac-1f0e-4620-8caa-f14ff960c132",
+          "65ce8cce-7b79-4ed6-8fa6-5836aef23d72",
+          "9LZjoShsSnl2XiV1V7y9G",
+          "gyhavOS-grCMzihxcxvyY",
+          "8cc40b5b-dda7-4f0c-805f-c6ffeadf2424",
+          "466b40e3-2e19-4587-ac32-ca1ab8a7a014"
         ],
         "ui": {
-          "active": false,
-          "left": 1163.767,
-          "top": 20.8357,
+          "x": 1072.517,
+          "y": 35.8357,
           "zIndex": 10,
           "widthName": 60,
-          "widthComment": 60
+          "widthComment": 60,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811744663,
+          "createAt": 1724811425586
+        }
       },
-      {
+      "d3458f78-11f7-4dc8-9990-5282aade4396": {
         "id": "d3458f78-11f7-4dc8-9990-5282aade4396",
         "name": "Box",
         "comment": "상자 UI",
-        "columns": [
-          {
-            "id": "0a823c91-d2cb-4f5f-96ab-558ab77782b2",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "b4b7944f-45fb-4f53-9889-e148954e74a7",
-            "name": "sequence",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "c5af32d7-64bc-4f6e-83e7-bae7fb4792bf",
-            "name": "normalImgUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 76.25587463378906,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "18324062-94ae-40d6-a0dc-0e6e8ee0d0d4",
-            "name": "setImgUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": false
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "ad3240c4-8420-4485-be20-c964d3f408fe",
-            "name": "smallImgUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": false
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 66.19389343261719,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "28d96503-2232-4717-8448-1cb06112bf72",
-            "name": "topImgUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": false
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "ba18f373-04f3-4fbf-9165-6dea2fcb149f",
-            "name": "kakaoMesageImgUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 111.0958251953125,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "0a823c91-d2cb-4f5f-96ab-558ab77782b2",
+          "b4b7944f-45fb-4f53-9889-e148954e74a7",
+          "c5af32d7-64bc-4f6e-83e7-bae7fb4792bf",
+          "18324062-94ae-40d6-a0dc-0e6e8ee0d0d4",
+          "ad3240c4-8420-4485-be20-c964d3f408fe",
+          "28d96503-2232-4717-8448-1cb06112bf72",
+          "ba18f373-04f3-4fbf-9165-6dea2fcb149f"
+        ],
+        "seqColumnIds": [
+          "0a823c91-d2cb-4f5f-96ab-558ab77782b2",
+          "b4b7944f-45fb-4f53-9889-e148954e74a7",
+          "c5af32d7-64bc-4f6e-83e7-bae7fb4792bf",
+          "18324062-94ae-40d6-a0dc-0e6e8ee0d0d4",
+          "ad3240c4-8420-4485-be20-c964d3f408fe",
+          "28d96503-2232-4717-8448-1cb06112bf72",
+          "ba18f373-04f3-4fbf-9165-6dea2fcb149f"
         ],
         "ui": {
-          "active": false,
-          "left": 1784.2549,
-          "top": 191.9507,
+          "x": 1784.2549,
+          "y": 191.9507,
           "zIndex": 56,
           "widthName": 60,
-          "widthComment": 60
+          "widthComment": 60,
+          "color": ""
         },
-        "visible": false
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
       },
-      {
+      "67c2763b-46ef-4967-821e-206a52e3c32c": {
         "id": "67c2763b-46ef-4967-821e-206a52e3c32c",
         "name": "Letter",
         "comment": "편지",
-        "columns": [
-          {
-            "id": "6d36f191-020b-427f-aa19-fca9b53ea4f1",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "8b0abbf6-3a5b-4b64-899d-8d77eb65a33a",
-            "name": "content",
-            "comment": "",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "151107b9-e942-47df-97dd-8b5de5918ce9",
-            "name": "envelopeId",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 62.29393005371094,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "6d36f191-020b-427f-aa19-fca9b53ea4f1",
+          "8b0abbf6-3a5b-4b64-899d-8d77eb65a33a",
+          "151107b9-e942-47df-97dd-8b5de5918ce9"
+        ],
+        "seqColumnIds": [
+          "6d36f191-020b-427f-aa19-fca9b53ea4f1",
+          "8b0abbf6-3a5b-4b64-899d-8d77eb65a33a",
+          "151107b9-e942-47df-97dd-8b5de5918ce9"
         ],
         "ui": {
-          "active": true,
-          "left": 1790.6982,
-          "top": 439.69,
+          "x": 1790.6982,
+          "y": 439.69,
           "zIndex": 59,
           "widthName": 60,
-          "widthComment": 60
+          "widthComment": 60,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
       },
-      {
+      "cb0209c5-3e02-4ac4-803c-33914ca2760d": {
         "id": "cb0209c5-3e02-4ac4-803c-33914ca2760d",
         "name": "Envelope",
         "comment": "편지 봉투 UI",
-        "columns": [
-          {
-            "id": "9d7e1a3b-bf8e-4e38-a95f-658b7957cc82",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "4f95a198-7819-4b09-95e4-2879aa5ac05d",
-            "name": "imgUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "8b59d3f4-b3f1-44f1-83be-08727f91cd82",
-            "name": "sequence",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "b94e7ef8-3ba1-473b-b346-3dbd36a15b31",
-            "name": "borderColorCode",
-            "comment": "",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 95.287841796875,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "9d7e1a3b-bf8e-4e38-a95f-658b7957cc82",
+          "4f95a198-7819-4b09-95e4-2879aa5ac05d",
+          "8b59d3f4-b3f1-44f1-83be-08727f91cd82",
+          "b94e7ef8-3ba1-473b-b346-3dbd36a15b31"
+        ],
+        "seqColumnIds": [
+          "9d7e1a3b-bf8e-4e38-a95f-658b7957cc82",
+          "4f95a198-7819-4b09-95e4-2879aa5ac05d",
+          "8b59d3f4-b3f1-44f1-83be-08727f91cd82",
+          "b94e7ef8-3ba1-473b-b346-3dbd36a15b31"
         ],
         "ui": {
-          "active": false,
-          "left": 1742.3673,
-          "top": 704.9369,
+          "x": 1742.3673,
+          "y": 704.9369,
           "zIndex": 58,
           "widthName": 60,
-          "widthComment": 65.6739501953125
+          "widthComment": 62,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
       },
-      {
+      "fc991fdb-6c22-4ee1-b5a7-a62126aa55ff": {
         "id": "fc991fdb-6c22-4ee1-b5a7-a62126aa55ff",
         "name": "Photo",
         "comment": "사진",
-        "columns": [
-          {
-            "id": "913c0941-71c6-461f-ae2c-d994c367206f",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "de69f269-72d0-403c-aa08-97b12491cdfe",
-            "name": "giftBoxId",
-            "comment": "UUID",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "fb3f6489-306e-4cd7-8000-15b7b8118da0",
-            "name": "imgUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "3029c1c8-0d1d-40bd-be58-8bf88740dd71",
-            "name": "description",
-            "comment": "사진 설명",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": false
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 62.77488708496094,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "9965d07a-0195-4944-be71-1eeab5b5ecf0",
-            "name": "sequence",
-            "comment": "",
-            "dataType": "INT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "913c0941-71c6-461f-ae2c-d994c367206f",
+          "de69f269-72d0-403c-aa08-97b12491cdfe",
+          "fb3f6489-306e-4cd7-8000-15b7b8118da0",
+          "3029c1c8-0d1d-40bd-be58-8bf88740dd71",
+          "9965d07a-0195-4944-be71-1eeab5b5ecf0"
+        ],
+        "seqColumnIds": [
+          "913c0941-71c6-461f-ae2c-d994c367206f",
+          "de69f269-72d0-403c-aa08-97b12491cdfe",
+          "fb3f6489-306e-4cd7-8000-15b7b8118da0",
+          "3029c1c8-0d1d-40bd-be58-8bf88740dd71",
+          "9965d07a-0195-4944-be71-1eeab5b5ecf0"
         ],
         "ui": {
-          "active": false,
-          "left": 1810.503,
-          "top": 7.8708,
+          "x": 1810.503,
+          "y": 7.8708,
           "zIndex": 2,
           "widthName": 60,
-          "widthComment": 60
+          "widthComment": 60,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "f742a7da-0ab3-4353-a499-3ddc65b7b050": {
         "id": "f742a7da-0ab3-4353-a499-3ddc65b7b050",
         "name": "ProfileImg",
         "comment": "프로필 이미지",
-        "columns": [
-          {
-            "id": "a1536917-8bda-4484-82ed-be52e2528949",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "bb43f127-df2e-4b3c-a0a4-b634ad1fff6e",
-            "name": "imgUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "66df3164-dc5b-4c7f-8c1a-5f9032f1bc9c",
-            "name": "sequence",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "a1536917-8bda-4484-82ed-be52e2528949",
+          "bb43f127-df2e-4b3c-a0a4-b634ad1fff6e",
+          "66df3164-dc5b-4c7f-8c1a-5f9032f1bc9c"
+        ],
+        "seqColumnIds": [
+          "a1536917-8bda-4484-82ed-be52e2528949",
+          "bb43f127-df2e-4b3c-a0a4-b634ad1fff6e",
+          "66df3164-dc5b-4c7f-8c1a-5f9032f1bc9c"
         ],
         "ui": {
-          "active": false,
-          "left": 637.8327,
-          "top": 615.2217,
+          "x": 649.0827,
+          "y": 720.2217,
           "zIndex": 6,
           "widthName": 60,
-          "widthComment": 72.88896179199219
+          "widthComment": 68,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811485720,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "f7dd4680-c8f4-4b8a-b764-2d5c27742e1b": {
         "id": "f7dd4680-c8f4-4b8a-b764-2d5c27742e1b",
         "name": "Music",
         "comment": "패키 유튜브 (Admin)",
-        "columns": [
-          {
-            "id": "a8ea215a-a2c2-4669-bba0-259843dd030c",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "ec0b0936-72f4-42ad-b2ea-5fa17601d323",
-            "name": "youtubeUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 63.06092834472656,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "0770b021-d473-46a4-adfa-faacf0e0c08f",
-            "name": "sequence",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "a8ea215a-a2c2-4669-bba0-259843dd030c",
+          "ec0b0936-72f4-42ad-b2ea-5fa17601d323",
+          "0770b021-d473-46a4-adfa-faacf0e0c08f"
+        ],
+        "seqColumnIds": [
+          "a8ea215a-a2c2-4669-bba0-259843dd030c",
+          "ec0b0936-72f4-42ad-b2ea-5fa17601d323",
+          "0770b021-d473-46a4-adfa-faacf0e0c08f"
         ],
         "ui": {
-          "active": false,
-          "left": 1296.8908,
-          "top": 800.7786,
+          "x": 1296.8908,
+          "y": 800.7786,
           "zIndex": 7,
           "widthName": 60,
-          "widthComment": 108.61288452148438
+          "widthComment": 105,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "18ab0bbe-f634-4cc1-9573-66fa5a02b2a3": {
         "id": "18ab0bbe-f634-4cc1-9573-66fa5a02b2a3",
         "name": "MusicHashtag",
         "comment": "해시태그",
-        "columns": [
-          {
-            "id": "b9104b9d-3dd4-4ce4-9451-6802e9785d1f",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "12a053bc-532a-489e-9176-fac838124255",
-            "name": "youtubeId",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "746c147e-4c52-422c-a955-84e6d1c5c881",
-            "name": "hashtag",
-            "comment": "",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "b9104b9d-3dd4-4ce4-9451-6802e9785d1f",
+          "12a053bc-532a-489e-9176-fac838124255",
+          "746c147e-4c52-422c-a955-84e6d1c5c881"
+        ],
+        "seqColumnIds": [
+          "b9104b9d-3dd4-4ce4-9451-6802e9785d1f",
+          "12a053bc-532a-489e-9176-fac838124255",
+          "746c147e-4c52-422c-a955-84e6d1c5c881"
         ],
         "ui": {
-          "active": false,
-          "left": 1719.336,
-          "top": 917.0005,
+          "x": 1719.336,
+          "y": 917.0005,
           "zIndex": 57,
-          "widthName": 77.81587219238281,
-          "widthComment": 60
+          "widthName": 83,
+          "widthComment": 60,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "5994e084-05c5-44c6-8bc7-2b09bf6e82da": {
         "id": "5994e084-05c5-44c6-8bc7-2b09bf6e82da",
         "name": "Sticker",
         "comment": "스티커",
-        "columns": [
-          {
-            "id": "29e97eff-8967-4e33-80fc-e273b45e07c5",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "20ea707e-2fe4-4d66-a77e-570b5c1a4369",
-            "name": "imgUrl",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "763ae73a-242e-4574-ad30-b9b497f71ccf",
-            "name": "sequence",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "29e97eff-8967-4e33-80fc-e273b45e07c5",
+          "20ea707e-2fe4-4d66-a77e-570b5c1a4369",
+          "763ae73a-242e-4574-ad30-b9b497f71ccf"
+        ],
+        "seqColumnIds": [
+          "29e97eff-8967-4e33-80fc-e273b45e07c5",
+          "20ea707e-2fe4-4d66-a77e-570b5c1a4369",
+          "763ae73a-242e-4574-ad30-b9b497f71ccf"
         ],
         "ui": {
-          "active": false,
-          "left": 1184,
-          "top": 657,
+          "x": 1184,
+          "y": 657,
           "zIndex": 9,
           "widthName": 60,
-          "widthComment": 60
+          "widthComment": 60,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "2bd92bc1-98cd-42d2-a70e-9e10942ad58f": {
         "id": "2bd92bc1-98cd-42d2-a70e-9e10942ad58f",
         "name": "GiftBoxSticker",
         "comment": "",
-        "columns": [
-          {
-            "id": "158c8b81-003d-4861-aa8c-234b3a12eb3b",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "76fc991c-14ab-440a-b545-a20c314c91a2",
-            "name": "giftboxId",
-            "comment": "UUID",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "0f79be76-3ce9-436c-a6e4-93f9fb627428",
-            "name": "stickerIid",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "3c755742-c723-41d9-bd5c-be93389d94ad",
-            "name": "location",
-            "comment": "",
-            "dataType": "INT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "158c8b81-003d-4861-aa8c-234b3a12eb3b",
+          "76fc991c-14ab-440a-b545-a20c314c91a2",
+          "0f79be76-3ce9-436c-a6e4-93f9fb627428",
+          "3c755742-c723-41d9-bd5c-be93389d94ad"
+        ],
+        "seqColumnIds": [
+          "158c8b81-003d-4861-aa8c-234b3a12eb3b",
+          "76fc991c-14ab-440a-b545-a20c314c91a2",
+          "0f79be76-3ce9-436c-a6e4-93f9fb627428",
+          "3c755742-c723-41d9-bd5c-be93389d94ad"
         ],
         "ui": {
-          "active": false,
-          "left": 1293,
-          "top": 421,
+          "x": 906.25,
+          "y": 507.25,
           "zIndex": 1,
-          "widthName": 79.92185974121094,
-          "widthComment": 60
+          "widthName": 83,
+          "widthComment": 60,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811668481,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "a1ae4699-f461-4a59-8cd3-c45b476defef": {
         "id": "a1ae4699-f461-4a59-8cd3-c45b476defef",
         "name": "Receiver",
         "comment": "선물 받은 사람",
-        "columns": [
-          {
-            "id": "b879b461-a0d9-402d-bf0b-e4de996ec1bd",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "8e61e4f6-34cb-4cc6-8c6b-d7d2e88c1430",
-            "name": "giftBoxId",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "fd989c07-4f8c-4e73-abe5-c160a2ad2dc1",
-            "name": "receiverId",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": true,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "de7379c5-6202-4413-85b4-184b235bca7c",
-            "name": "createdAt",
-            "comment": "",
-            "dataType": "TIMESTAMP",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 68.2479248046875,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "c6fbcbc7-b4cf-4cf0-a995-354f400d2b6a",
-            "name": "updatedAt",
-            "comment": "",
-            "dataType": "TIMESTAMP",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 68.2479248046875,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "b879b461-a0d9-402d-bf0b-e4de996ec1bd",
+          "8e61e4f6-34cb-4cc6-8c6b-d7d2e88c1430",
+          "fd989c07-4f8c-4e73-abe5-c160a2ad2dc1",
+          "de7379c5-6202-4413-85b4-184b235bca7c",
+          "c6fbcbc7-b4cf-4cf0-a995-354f400d2b6a"
+        ],
+        "seqColumnIds": [
+          "b879b461-a0d9-402d-bf0b-e4de996ec1bd",
+          "8e61e4f6-34cb-4cc6-8c6b-d7d2e88c1430",
+          "fd989c07-4f8c-4e73-abe5-c160a2ad2dc1",
+          "de7379c5-6202-4413-85b4-184b235bca7c",
+          "c6fbcbc7-b4cf-4cf0-a995-354f400d2b6a"
         ],
         "ui": {
-          "active": false,
-          "left": 868.8884,
-          "top": 400.0006,
+          "x": 542.6384,
+          "y": 90.0006,
           "zIndex": 13,
           "widthName": 60,
-          "widthComment": 76.30795288085938
+          "widthComment": 71,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811544199,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "d81ebbcf-fbc5-4e81-a7aa-13cf3c5cab39": {
         "id": "d81ebbcf-fbc5-4e81-a7aa-13cf3c5cab39",
         "name": "Setting",
         "comment": "설정",
-        "columns": [
-          {
-            "id": "d4ea9e4e-2913-4129-a1b3-e027100c110e",
-            "name": "id",
-            "comment": "",
-            "dataType": "BIGINT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": true,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": true,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "feaf62d7-bbd7-4969-988a-4c207864dd9d",
-            "name": "tag",
-            "comment": "ex) OFFICIAL_SNS",
-            "dataType": "VARCHAR",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 99.12284851074219,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          },
-          {
-            "id": "8ab44e4f-0a67-4f7b-ba0f-a3950c02a7c7",
-            "name": "url",
-            "comment": "",
-            "dataType": "TEXT",
-            "default": "",
-            "option": {
-              "autoIncrement": false,
-              "primaryKey": false,
-              "unique": false,
-              "notNull": true
-            },
-            "ui": {
-              "active": false,
-              "pk": false,
-              "fk": false,
-              "pfk": false,
-              "widthName": 60,
-              "widthComment": 60,
-              "widthDataType": 60,
-              "widthDefault": 60
-            }
-          }
+        "columnIds": [
+          "d4ea9e4e-2913-4129-a1b3-e027100c110e",
+          "feaf62d7-bbd7-4969-988a-4c207864dd9d",
+          "8ab44e4f-0a67-4f7b-ba0f-a3950c02a7c7"
+        ],
+        "seqColumnIds": [
+          "d4ea9e4e-2913-4129-a1b3-e027100c110e",
+          "feaf62d7-bbd7-4969-988a-4c207864dd9d",
+          "8ab44e4f-0a67-4f7b-ba0f-a3950c02a7c7"
         ],
         "ui": {
-          "active": false,
-          "left": 736.0442,
-          "top": 769.2657,
+          "x": 737.2942,
+          "y": 880.5157,
           "zIndex": 11,
           "widthName": 60,
-          "widthComment": 60
+          "widthComment": 60,
+          "color": ""
         },
-        "visible": true
+        "meta": {
+          "updateAt": 1724811482986,
+          "createAt": 1724811425587
+        }
       }
-    ],
-    "indexes": []
-  },
-  "memo": {
-    "memos": []
-  },
-  "relationship": {
-    "relationships": [
-      {
+    },
+    "tableColumnEntities": {
+      "e425f403-77ff-4332-acac-340f8cb521aa": {
+        "id": "e425f403-77ff-4332-acac-340f8cb521aa",
+        "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "c23828d4-9b90-490a-8ff1-34ccaf093c16": {
+        "id": "c23828d4-9b90-490a-8ff1-34ccaf093c16",
+        "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
+        "name": "nickname",
+        "comment": "6자 이내",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "1585a43a-06c5-4e3a-8a9f-09fd4f590bda": {
+        "id": "1585a43a-06c5-4e3a-8a9f-09fd4f590bda",
+        "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
+        "name": "loginType",
+        "comment": "admin, kakao, apple",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 114,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "0b2af273-08a4-4ac8-9fa2-e3a5ce8ca200": {
+        "id": "0b2af273-08a4-4ac8-9fa2-e3a5ce8ca200",
+        "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
+        "name": "pushNotification",
+        "comment": "",
+        "dataType": "TINYINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 95,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "e7d2c702-6d5b-48cb-bbf3-ad2d3460fb33": {
+        "id": "e7d2c702-6d5b-48cb-bbf3-ad2d3460fb33",
+        "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
+        "name": "profileImgId",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 70,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "aa26bea4-eef2-41d7-b1e9-41deb3fc0280": {
+        "id": "aa26bea4-eef2-41d7-b1e9-41deb3fc0280",
+        "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
+        "name": "isWithdrawal",
+        "comment": "탈퇴 여부",
+        "dataType": "TINYINT",
+        "default": "false",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 74,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "ec074e1a-fb92-45b7-a212-ab25fbfee79e": {
+        "id": "ec074e1a-fb92-45b7-a212-ab25fbfee79e",
+        "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
+        "name": "marketingAgreement",
+        "comment": "",
+        "dataType": "TINYINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 120,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "53ac6902-c916-49a3-85aa-e39eac339f02": {
+        "id": "53ac6902-c916-49a3-85aa-e39eac339f02",
+        "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
+        "name": "createdAt",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "b04d1899-b2fd-42f2-9123-44474dc793f9": {
+        "id": "b04d1899-b2fd-42f2-9123-44474dc793f9",
+        "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
+        "name": "updatedAt",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 61,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "1f0095df-47d9-44ee-9992-1d5cf1102126": {
+        "id": "1f0095df-47d9-44ee-9992-1d5cf1102126",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "784b87f3-056e-4fa1-8864-bdd7f822caef": {
+        "id": "784b87f3-056e-4fa1-8864-bdd7f822caef",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "senderId",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "8f314eec-c651-4b78-9f08-cb356f4e9519": {
+        "id": "8f314eec-c651-4b78-9f08-cb356f4e9519",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "boxId",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "3f89ecfc-e228-4223-b30d-35558abba959": {
+        "id": "3f89ecfc-e228-4223-b30d-35558abba959",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "letterId",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "4e16cace-2815-497f-b773-3e430d7ddc7b": {
+        "id": "4e16cace-2815-497f-b773-3e430d7ddc7b",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "uuid",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "ed996d2f-167f-4e07-a4cc-937ce1a22c29": {
+        "id": "ed996d2f-167f-4e07-a4cc-937ce1a22c29",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "name",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "40ca0888-f5d5-46bb-9e30-788f294a226b": {
+        "id": "40ca0888-f5d5-46bb-9e30-788f294a226b",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "youtubeUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 64,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "a698d729-4e16-4df0-badf-9f400e69e257": {
+        "id": "a698d729-4e16-4df0-badf-9f400e69e257",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "giftType",
+        "comment": "PHOTO, LINK",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 77,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811707645,
+          "createAt": 1724811425586
+        }
+      },
+      "d07f885a-1916-4dd1-a8f7-0a1a68f72a43": {
+        "id": "d07f885a-1916-4dd1-a8f7-0a1a68f72a43",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "giftMessage",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 72,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "4f4705ac-1f0e-4620-8caa-f14ff960c132": {
+        "id": "4f4705ac-1f0e-4620-8caa-f14ff960c132",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "senderName",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 74,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "65ce8cce-7b79-4ed6-8fa6-5836aef23d72": {
+        "id": "65ce8cce-7b79-4ed6-8fa6-5836aef23d72",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "receiverName",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 80,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "8cc40b5b-dda7-4f0c-805f-c6ffeadf2424": {
+        "id": "8cc40b5b-dda7-4f0c-805f-c6ffeadf2424",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "createdAt",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "466b40e3-2e19-4587-ac32-ca1ab8a7a014": {
+        "id": "466b40e3-2e19-4587-ac32-ca1ab8a7a014",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "updatedAt",
+        "comment": "수정 기능은 없지만 BaseTimeEntity를 사용하기 위해 추가",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 61,
+          "widthComment": 285,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "0a823c91-d2cb-4f5f-96ab-558ab77782b2": {
+        "id": "0a823c91-d2cb-4f5f-96ab-558ab77782b2",
+        "tableId": "d3458f78-11f7-4dc8-9990-5282aade4396",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "b4b7944f-45fb-4f53-9889-e148954e74a7": {
+        "id": "b4b7944f-45fb-4f53-9889-e148954e74a7",
+        "tableId": "d3458f78-11f7-4dc8-9990-5282aade4396",
+        "name": "sequence",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "c5af32d7-64bc-4f6e-83e7-bae7fb4792bf": {
+        "id": "c5af32d7-64bc-4f6e-83e7-bae7fb4792bf",
+        "tableId": "d3458f78-11f7-4dc8-9990-5282aade4396",
+        "name": "normalImgUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 78,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "18324062-94ae-40d6-a0dc-0e6e8ee0d0d4": {
+        "id": "18324062-94ae-40d6-a0dc-0e6e8ee0d0d4",
+        "tableId": "d3458f78-11f7-4dc8-9990-5282aade4396",
+        "name": "setImgUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "ad3240c4-8420-4485-be20-c964d3f408fe": {
+        "id": "ad3240c4-8420-4485-be20-c964d3f408fe",
+        "tableId": "d3458f78-11f7-4dc8-9990-5282aade4396",
+        "name": "smallImgUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "28d96503-2232-4717-8448-1cb06112bf72": {
+        "id": "28d96503-2232-4717-8448-1cb06112bf72",
+        "tableId": "d3458f78-11f7-4dc8-9990-5282aade4396",
+        "name": "topImgUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "ba18f373-04f3-4fbf-9165-6dea2fcb149f": {
+        "id": "ba18f373-04f3-4fbf-9165-6dea2fcb149f",
+        "tableId": "d3458f78-11f7-4dc8-9990-5282aade4396",
+        "name": "kakaoMesageImgUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 117,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "6d36f191-020b-427f-aa19-fca9b53ea4f1": {
+        "id": "6d36f191-020b-427f-aa19-fca9b53ea4f1",
+        "tableId": "67c2763b-46ef-4967-821e-206a52e3c32c",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "8b0abbf6-3a5b-4b64-899d-8d77eb65a33a": {
+        "id": "8b0abbf6-3a5b-4b64-899d-8d77eb65a33a",
+        "tableId": "67c2763b-46ef-4967-821e-206a52e3c32c",
+        "name": "content",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "151107b9-e942-47df-97dd-8b5de5918ce9": {
+        "id": "151107b9-e942-47df-97dd-8b5de5918ce9",
+        "tableId": "67c2763b-46ef-4967-821e-206a52e3c32c",
+        "name": "envelopeId",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 64,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425586,
+          "createAt": 1724811425586
+        }
+      },
+      "9d7e1a3b-bf8e-4e38-a95f-658b7957cc82": {
+        "id": "9d7e1a3b-bf8e-4e38-a95f-658b7957cc82",
+        "tableId": "cb0209c5-3e02-4ac4-803c-33914ca2760d",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "4f95a198-7819-4b09-95e4-2879aa5ac05d": {
+        "id": "4f95a198-7819-4b09-95e4-2879aa5ac05d",
+        "tableId": "cb0209c5-3e02-4ac4-803c-33914ca2760d",
+        "name": "imgUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "8b59d3f4-b3f1-44f1-83be-08727f91cd82": {
+        "id": "8b59d3f4-b3f1-44f1-83be-08727f91cd82",
+        "tableId": "cb0209c5-3e02-4ac4-803c-33914ca2760d",
+        "name": "sequence",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "b94e7ef8-3ba1-473b-b346-3dbd36a15b31": {
+        "id": "b94e7ef8-3ba1-473b-b346-3dbd36a15b31",
+        "tableId": "cb0209c5-3e02-4ac4-803c-33914ca2760d",
+        "name": "borderColorCode",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 100,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "913c0941-71c6-461f-ae2c-d994c367206f": {
+        "id": "913c0941-71c6-461f-ae2c-d994c367206f",
+        "tableId": "fc991fdb-6c22-4ee1-b5a7-a62126aa55ff",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "de69f269-72d0-403c-aa08-97b12491cdfe": {
+        "id": "de69f269-72d0-403c-aa08-97b12491cdfe",
+        "tableId": "fc991fdb-6c22-4ee1-b5a7-a62126aa55ff",
+        "name": "giftBoxId",
+        "comment": "UUID",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "fb3f6489-306e-4cd7-8000-15b7b8118da0": {
+        "id": "fb3f6489-306e-4cd7-8000-15b7b8118da0",
+        "tableId": "fc991fdb-6c22-4ee1-b5a7-a62126aa55ff",
+        "name": "imgUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "3029c1c8-0d1d-40bd-be58-8bf88740dd71": {
+        "id": "3029c1c8-0d1d-40bd-be58-8bf88740dd71",
+        "tableId": "fc991fdb-6c22-4ee1-b5a7-a62126aa55ff",
+        "name": "description",
+        "comment": "사진 설명",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 0,
+        "ui": {
+          "keys": 0,
+          "widthName": 65,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "9965d07a-0195-4944-be71-1eeab5b5ecf0": {
+        "id": "9965d07a-0195-4944-be71-1eeab5b5ecf0",
+        "tableId": "fc991fdb-6c22-4ee1-b5a7-a62126aa55ff",
+        "name": "sequence",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "a1536917-8bda-4484-82ed-be52e2528949": {
+        "id": "a1536917-8bda-4484-82ed-be52e2528949",
+        "tableId": "f742a7da-0ab3-4353-a499-3ddc65b7b050",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "bb43f127-df2e-4b3c-a0a4-b634ad1fff6e": {
+        "id": "bb43f127-df2e-4b3c-a0a4-b634ad1fff6e",
+        "tableId": "f742a7da-0ab3-4353-a499-3ddc65b7b050",
+        "name": "imgUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "66df3164-dc5b-4c7f-8c1a-5f9032f1bc9c": {
+        "id": "66df3164-dc5b-4c7f-8c1a-5f9032f1bc9c",
+        "tableId": "f742a7da-0ab3-4353-a499-3ddc65b7b050",
+        "name": "sequence",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "a8ea215a-a2c2-4669-bba0-259843dd030c": {
+        "id": "a8ea215a-a2c2-4669-bba0-259843dd030c",
+        "tableId": "f7dd4680-c8f4-4b8a-b764-2d5c27742e1b",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "ec0b0936-72f4-42ad-b2ea-5fa17601d323": {
+        "id": "ec0b0936-72f4-42ad-b2ea-5fa17601d323",
+        "tableId": "f7dd4680-c8f4-4b8a-b764-2d5c27742e1b",
+        "name": "youtubeUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 64,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "0770b021-d473-46a4-adfa-faacf0e0c08f": {
+        "id": "0770b021-d473-46a4-adfa-faacf0e0c08f",
+        "tableId": "f7dd4680-c8f4-4b8a-b764-2d5c27742e1b",
+        "name": "sequence",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "b9104b9d-3dd4-4ce4-9451-6802e9785d1f": {
+        "id": "b9104b9d-3dd4-4ce4-9451-6802e9785d1f",
+        "tableId": "18ab0bbe-f634-4cc1-9573-66fa5a02b2a3",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "12a053bc-532a-489e-9176-fac838124255": {
+        "id": "12a053bc-532a-489e-9176-fac838124255",
+        "tableId": "18ab0bbe-f634-4cc1-9573-66fa5a02b2a3",
+        "name": "youtubeId",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "746c147e-4c52-422c-a955-84e6d1c5c881": {
+        "id": "746c147e-4c52-422c-a955-84e6d1c5c881",
+        "tableId": "18ab0bbe-f634-4cc1-9573-66fa5a02b2a3",
+        "name": "hashtag",
+        "comment": "",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "29e97eff-8967-4e33-80fc-e273b45e07c5": {
+        "id": "29e97eff-8967-4e33-80fc-e273b45e07c5",
+        "tableId": "5994e084-05c5-44c6-8bc7-2b09bf6e82da",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "20ea707e-2fe4-4d66-a77e-570b5c1a4369": {
+        "id": "20ea707e-2fe4-4d66-a77e-570b5c1a4369",
+        "tableId": "5994e084-05c5-44c6-8bc7-2b09bf6e82da",
+        "name": "imgUrl",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "763ae73a-242e-4574-ad30-b9b497f71ccf": {
+        "id": "763ae73a-242e-4574-ad30-b9b497f71ccf",
+        "tableId": "5994e084-05c5-44c6-8bc7-2b09bf6e82da",
+        "name": "sequence",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "158c8b81-003d-4861-aa8c-234b3a12eb3b": {
+        "id": "158c8b81-003d-4861-aa8c-234b3a12eb3b",
+        "tableId": "2bd92bc1-98cd-42d2-a70e-9e10942ad58f",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "76fc991c-14ab-440a-b545-a20c314c91a2": {
+        "id": "76fc991c-14ab-440a-b545-a20c314c91a2",
+        "tableId": "2bd92bc1-98cd-42d2-a70e-9e10942ad58f",
+        "name": "giftboxId",
+        "comment": "UUID",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "0f79be76-3ce9-436c-a6e4-93f9fb627428": {
+        "id": "0f79be76-3ce9-436c-a6e4-93f9fb627428",
+        "tableId": "2bd92bc1-98cd-42d2-a70e-9e10942ad58f",
+        "name": "stickerIid",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "3c755742-c723-41d9-bd5c-be93389d94ad": {
+        "id": "3c755742-c723-41d9-bd5c-be93389d94ad",
+        "tableId": "2bd92bc1-98cd-42d2-a70e-9e10942ad58f",
+        "name": "location",
+        "comment": "",
+        "dataType": "INT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "b879b461-a0d9-402d-bf0b-e4de996ec1bd": {
+        "id": "b879b461-a0d9-402d-bf0b-e4de996ec1bd",
+        "tableId": "a1ae4699-f461-4a59-8cd3-c45b476defef",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "8e61e4f6-34cb-4cc6-8c6b-d7d2e88c1430": {
+        "id": "8e61e4f6-34cb-4cc6-8c6b-d7d2e88c1430",
+        "tableId": "a1ae4699-f461-4a59-8cd3-c45b476defef",
+        "name": "giftBoxId",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "fd989c07-4f8c-4e73-abe5-c160a2ad2dc1": {
+        "id": "fd989c07-4f8c-4e73-abe5-c160a2ad2dc1",
+        "tableId": "a1ae4699-f461-4a59-8cd3-c45b476defef",
+        "name": "receiverId",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "de7379c5-6202-4413-85b4-184b235bca7c": {
+        "id": "de7379c5-6202-4413-85b4-184b235bca7c",
+        "tableId": "a1ae4699-f461-4a59-8cd3-c45b476defef",
+        "name": "createdAt",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "c6fbcbc7-b4cf-4cf0-a995-354f400d2b6a": {
+        "id": "c6fbcbc7-b4cf-4cf0-a995-354f400d2b6a",
+        "tableId": "a1ae4699-f461-4a59-8cd3-c45b476defef",
+        "name": "updatedAt",
+        "comment": "",
+        "dataType": "TIMESTAMP",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 61,
+          "widthComment": 60,
+          "widthDataType": 71,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "d4ea9e4e-2913-4129-a1b3-e027100c110e": {
+        "id": "d4ea9e4e-2913-4129-a1b3-e027100c110e",
+        "tableId": "d81ebbcf-fbc5-4e81-a7aa-13cf3c5cab39",
+        "name": "id",
+        "comment": "",
+        "dataType": "BIGINT",
+        "default": "",
+        "options": 10,
+        "ui": {
+          "keys": 1,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "feaf62d7-bbd7-4969-988a-4c207864dd9d": {
+        "id": "feaf62d7-bbd7-4969-988a-4c207864dd9d",
+        "tableId": "d81ebbcf-fbc5-4e81-a7aa-13cf3c5cab39",
+        "name": "tag",
+        "comment": "ex) OFFICIAL_SNS",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 107,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "8ab44e4f-0a67-4f7b-ba0f-a3950c02a7c7": {
+        "id": "8ab44e4f-0a67-4f7b-ba0f-a3950c02a7c7",
+        "tableId": "d81ebbcf-fbc5-4e81-a7aa-13cf3c5cab39",
+        "name": "url",
+        "comment": "",
+        "dataType": "TEXT",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      },
+      "NuVu_F5fkC8RAD53CCGJF": {
+        "id": "NuVu_F5fkC8RAD53CCGJF",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "giftBoxType",
+        "comment": "PRIVATE, SEMI_PUBLIC, PUBLIC",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 69,
+          "widthComment": 185,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811658543,
+          "createAt": 1724811625730
+        }
+      },
+      "gyhavOS-grCMzihxcxvyY": {
+        "id": "gyhavOS-grCMzihxcxvyY",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "devliverStatus",
+        "comment": "WAITING, DELIVERED",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 83,
+          "widthComment": 125,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811700096,
+          "createAt": 1724811669791
+        }
+      },
+      "9LZjoShsSnl2XiV1V7y9G": {
+        "id": "9LZjoShsSnl2XiV1V7y9G",
+        "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
+        "name": "senderDeleted",
+        "comment": "",
+        "dataType": "TINYINT",
+        "default": "false",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 85,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1724811732079,
+          "createAt": 1724811714725
+        }
+      }
+    },
+    "relationshipEntities": {
+      "d6d41908-171e-4016-883a-8d62102243b0": {
         "id": "d6d41908-171e-4016-883a-8d62102243b0",
         "identification": false,
-        "relationshipType": "OneOnly",
-        "startRelationshipType": "Dash",
+        "relationshipType": 8,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "67c2763b-46ef-4967-821e-206a52e3c32c",
           "columnIds": [
             "6d36f191-020b-427f-aa19-fca9b53ea4f1"
           ],
           "x": 1790.6982,
-          "y": 504.94,
-          "direction": "left"
+          "y": 503.69,
+          "direction": 1
         },
         "end": {
           "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
           "columnIds": [
             "3f89ecfc-e228-4223-b30d-35558abba959"
           ],
-          "x": 1596.4408433837891,
-          "y": 300.4190333333333,
-          "direction": "right"
+          "x": 1698.517,
+          "y": 382.5023666666666,
+          "direction": 2
         },
-        "constraintName": "fk_letter_to_present",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "55ea086f-38cc-4a04-92cb-5e2784228d1d": {
         "id": "55ea086f-38cc-4a04-92cb-5e2784228d1d",
         "identification": false,
-        "relationshipType": "OneN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 16,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "cb0209c5-3e02-4ac4-803c-33914ca2760d",
           "columnIds": [
             "9d7e1a3b-bf8e-4e38-a95f-658b7957cc82"
           ],
-          "x": 1933.5112208984374,
+          "x": 1944.8673,
           "y": 704.9369,
-          "direction": "top"
+          "direction": 4
         },
         "end": {
           "tableId": "67c2763b-46ef-4967-821e-206a52e3c32c",
           "columnIds": [
             "151107b9-e942-47df-97dd-8b5de5918ce9"
           ],
-          "x": 1965.3451650268555,
-          "y": 570.19,
-          "direction": "bottom"
+          "x": 1975.1982,
+          "y": 567.69,
+          "direction": 8
         },
-        "constraintName": "fk_envelope_to_letter",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "cb104e2f-38dc-4a19-9587-d63ee984b48b": {
         "id": "cb104e2f-38dc-4a19-9587-d63ee984b48b",
         "identification": false,
-        "relationshipType": "OneN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 16,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
           "columnIds": [
             "1f0095df-47d9-44ee-9992-1d5cf1102126"
           ],
-          "x": 1596.4408433837891,
-          "y": 76.75236666666666,
-          "direction": "right"
+          "x": 1698.517,
+          "y": 105.16903333333333,
+          "direction": 2
         },
         "end": {
           "tableId": "fc991fdb-6c22-4ee1-b5a7-a62126aa55ff",
@@ -1825,51 +1911,55 @@
             "de69f269-72d0-403c-aa08-97b12491cdfe"
           ],
           "x": 1810.503,
-          "y": 93.6208,
-          "direction": "left"
+          "y": 95.8708,
+          "direction": 1
         },
-        "constraintName": "fk_present_to_photo",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "ae457558-3496-4299-9870-a13872fc842d": {
         "id": "ae457558-3496-4299-9870-a13872fc842d",
         "identification": false,
-        "relationshipType": "OneN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 16,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "f742a7da-0ab3-4353-a499-3ddc65b7b050",
           "columnIds": [
             "a1536917-8bda-4484-82ed-be52e2528949"
           ],
-          "x": 811.3327,
-          "y": 615.2217,
-          "direction": "top"
+          "x": 649.0827,
+          "y": 784.2217,
+          "direction": 1
         },
         "end": {
           "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
           "columnIds": [
             "e7d2c702-6d5b-48cb-bbf3-ad2d3460fb33"
           ],
-          "x": 679.938640625,
-          "y": 287.9444,
-          "direction": "bottom"
+          "x": 646.4445000000001,
+          "y": 690.1944,
+          "direction": 2
         },
-        "constraintName": "fk_profileimg_to_member",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "7bea2bc5-9ba0-4e83-8287-245e37868355": {
         "id": "7bea2bc5-9ba0-4e83-8287-245e37868355",
         "identification": false,
-        "relationshipType": "ZeroN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 4,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "f7dd4680-c8f4-4b8a-b764-2d5c27742e1b",
           "columnIds": [
             "a8ea215a-a2c2-4669-bba0-259843dd030c"
           ],
-          "x": 1646.9517283447265,
-          "y": 866.0286,
-          "direction": "right"
+          "x": 1665.8908,
+          "y": 864.7786,
+          "direction": 2
         },
         "end": {
           "tableId": "18ab0bbe-f634-4cc1-9573-66fa5a02b2a3",
@@ -1877,167 +1967,233 @@
             "12a053bc-532a-489e-9176-fac838124255"
           ],
           "x": 1719.336,
-          "y": 982.2505,
-          "direction": "left"
+          "y": 981.0005,
+          "direction": 1
         },
-        "constraintName": "fk_youtube_to_hashtag",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "c395606a-ed58-46b8-9e45-8d23df5b6fcc": {
         "id": "c395606a-ed58-46b8-9e45-8d23df5b6fcc",
         "identification": false,
-        "relationshipType": "ZeroN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 4,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "d3458f78-11f7-4dc8-9990-5282aade4396",
           "columnIds": [
             "0a823c91-d2cb-4f5f-96ab-558ab77782b2"
           ],
           "x": 1784.2549,
-          "y": 298.2007,
-          "direction": "left"
+          "y": 303.9507,
+          "direction": 1
         },
         "end": {
           "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
           "columnIds": [
             "8f314eec-c651-4b78-9f08-cb356f4e9519"
           ],
-          "x": 1596.4408433837891,
-          "y": 188.58569999999997,
-          "direction": "right"
+          "x": 1698.517,
+          "y": 243.83569999999997,
+          "direction": 2
         },
-        "constraintName": "fk_box_to_giftbox",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "60336fdd-2c1c-4517-8ef3-5f1caf9a0a4f": {
         "id": "60336fdd-2c1c-4517-8ef3-5f1caf9a0a4f",
         "identification": false,
-        "relationshipType": "OneN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 16,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
           "columnIds": [
             "1f0095df-47d9-44ee-9992-1d5cf1102126"
           ],
-          "x": 1488.2723825378418,
-          "y": 356.3357,
-          "direction": "bottom"
+          "x": 1385.517,
+          "y": 451.8357,
+          "direction": 8
         },
         "end": {
           "tableId": "2bd92bc1-98cd-42d2-a70e-9e10942ad58f",
           "columnIds": [
             "76fc991c-14ab-440a-b545-a20c314c91a2"
           ],
-          "x": 1466.5,
-          "y": 421,
-          "direction": "top"
+          "x": 1271.25,
+          "y": 583.25,
+          "direction": 2
         },
-        "constraintName": "fk_giftbox_to_giftboxsticker",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "d36e79c8-1f2f-435b-aaa7-32138fc18c77": {
         "id": "d36e79c8-1f2f-435b-aaa7-32138fc18c77",
         "identification": false,
-        "relationshipType": "OneN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 16,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "5994e084-05c5-44c6-8bc7-2b09bf6e82da",
           "columnIds": [
             "29e97eff-8967-4e33-80fc-e273b45e07c5"
           ],
-          "x": 1357.5,
-          "y": 657,
-          "direction": "top"
+          "x": 1184,
+          "y": 721,
+          "direction": 1
         },
         "end": {
           "tableId": "2bd92bc1-98cd-42d2-a70e-9e10942ad58f",
           "columnIds": [
             "0f79be76-3ce9-436c-a6e4-93f9fb627428"
           ],
-          "x": 1466.5,
-          "y": 572,
-          "direction": "bottom"
+          "x": 1088.75,
+          "y": 659.25,
+          "direction": 8
         },
-        "constraintName": "fk_sticker_to_giftboxsticker",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "5d15a1c1-e33c-44c2-82f9-026a447bb5a5": {
         "id": "5d15a1c1-e33c-44c2-82f9-026a447bb5a5",
         "identification": false,
-        "relationshipType": "ZeroN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 4,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
           "columnIds": [
             "e425f403-77ff-4332-acac-340f8cb521aa"
           ],
-          "x": 1026.4210625,
-          "y": 161.1944,
-          "direction": "right"
+          "x": 646.4445000000001,
+          "y": 554.1944,
+          "direction": 2
         },
         "end": {
           "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
           "columnIds": [
             "784b87f3-056e-4fa1-8864-bdd7f822caef"
           ],
-          "x": 1163.767,
-          "y": 188.5857,
-          "direction": "left"
+          "x": 1072.517,
+          "y": 347.8357,
+          "direction": 1
         },
-        "constraintName": "fk_member_to_giftbox",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "5ed41cd3-9940-405e-bf80-43412bfa31c6": {
         "id": "5ed41cd3-9940-405e-bf80-43412bfa31c6",
         "identification": false,
-        "relationshipType": "OneN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 16,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "47966f5e-3bfe-4d71-91d6-e0003848c932",
           "columnIds": [
             "1f0095df-47d9-44ee-9992-1d5cf1102126"
           ],
-          "x": 1271.9354608459473,
-          "y": 356.3357,
-          "direction": "bottom"
+          "x": 1072.517,
+          "y": 139.8357,
+          "direction": 1
         },
         "end": {
           "tableId": "a1ae4699-f461-4a59-8cd3-c45b476defef",
           "columnIds": [
             "8e61e4f6-34cb-4cc6-8c6b-d7d2e88c1430"
           ],
-          "x": 1224.1363248046875,
-          "y": 485.7506,
-          "direction": "right"
+          "x": 919.6384,
+          "y": 178.00060000000002,
+          "direction": 2
         },
-        "constraintName": "fk_giftbox_to_receiver",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
       },
-      {
+      "395dcfa0-1299-4777-9998-e6749384d061": {
         "id": "395dcfa0-1299-4777-9998-e6749384d061",
         "identification": false,
-        "relationshipType": "ZeroN",
-        "startRelationshipType": "Dash",
+        "relationshipType": 4,
+        "startRelationshipType": 2,
         "start": {
           "tableId": "cd084f39-b9f7-4756-b509-21e56852208d",
           "columnIds": [
             "e425f403-77ff-4332-acac-340f8cb521aa"
           ],
-          "x": 910.926921875,
-          "y": 287.9444,
-          "direction": "bottom"
+          "x": 401.4445,
+          "y": 486.1944,
+          "direction": 4
         },
         "end": {
           "tableId": "a1ae4699-f461-4a59-8cd3-c45b476defef",
           "columnIds": [
             "fd989c07-4f8c-4e73-abe5-c160a2ad2dc1"
           ],
-          "x": 868.8884,
-          "y": 485.7506,
-          "direction": "left"
+          "x": 542.6384,
+          "y": 178.00060000000002,
+          "direction": 1
         },
-        "constraintName": "fk_member_to_receiver",
-        "visible": true
+        "meta": {
+          "updateAt": 1724811425587,
+          "createAt": 1724811425587
+        }
+      }
+    },
+    "indexEntities": {},
+    "indexColumnEntities": {},
+    "memoEntities": {}
+  },
+  "lww": {
+    "65ce8cce-7b79-4ed6-8fa6-5836aef23d72": [
+      "tableColumnEntities",
+      -1,
+      1724811593966,
+      {}
+    ],
+    "NuVu_F5fkC8RAD53CCGJF": [
+      "tableColumnEntities",
+      1724811625729,
+      -1,
+      {
+        "name": 1724811636737,
+        "dataType": 1724811642661,
+        "options(notNull)": 1724811644311,
+        "comment": 1724811658542
+      }
+    ],
+    "gyhavOS-grCMzihxcxvyY": [
+      "tableColumnEntities",
+      1724811669791,
+      -1,
+      {
+        "name": 1724811683698,
+        "dataType": 1724811685710,
+        "options(notNull)": 1724811686866,
+        "comment": 1724811700095
+      }
+    ],
+    "a698d729-4e16-4df0-badf-9f400e69e257": [
+      "tableColumnEntities",
+      -1,
+      -1,
+      {
+        "comment": 1724811707644
+      }
+    ],
+    "9LZjoShsSnl2XiV1V7y9G": [
+      "tableColumnEntities",
+      1724811714724,
+      -1,
+      {
+        "name": 1724811720076,
+        "dataType": 1724811727292,
+        "options(notNull)": 1724811728190,
+        "default": 1724811732078
       }
     ]
   }

--- a/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
+++ b/packy-api/src/main/java/com/dilly/auth/application/AuthService.java
@@ -12,7 +12,6 @@ import com.dilly.gift.adaptor.ReceiverWriter;
 import com.dilly.gift.domain.giftbox.GiftBox;
 import com.dilly.gift.domain.giftbox.admin.AdminGiftBox;
 import com.dilly.gift.domain.giftbox.admin.AdminType;
-import com.dilly.global.util.SecurityUtil;
 import com.dilly.jwt.JwtService;
 import com.dilly.jwt.RefreshToken;
 import com.dilly.jwt.adaptor.JwtReader;
@@ -20,6 +19,7 @@ import com.dilly.jwt.adaptor.JwtWriter;
 import com.dilly.jwt.dto.JwtResponse;
 import com.dilly.member.adaptor.MemberReader;
 import com.dilly.member.adaptor.ProfileImageReader;
+import com.dilly.member.application.MemberService;
 import com.dilly.member.domain.Member;
 import com.dilly.member.domain.ProfileImage;
 import com.dilly.member.domain.Provider;
@@ -42,6 +42,7 @@ public class AuthService {
 
 	private final AuthActionProvider authActionProvider;
 
+	private final MemberService memberService;
 	private final JwtService jwtService;
 
 	private final MemberReader memberReader;
@@ -95,8 +96,7 @@ public class AuthService {
 	}
 
 	public String withdraw() {
-		Long memberId = SecurityUtil.getMemberId();
-		Member member = memberReader.findById(memberId);
+		Member member = memberService.getMember();
 
 		final AuthStrategy authStrategy = authActionProvider.getStrategy(member.getProvider());
 		authStrategy.withdraw(member);

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftBoxService.java
@@ -44,9 +44,8 @@ import com.dilly.gift.dto.response.MainGiftBoxResponse;
 import com.dilly.gift.dto.response.PhotoResponseDto.PhotoResponse;
 import com.dilly.gift.dto.response.StickerResponse;
 import com.dilly.gift.dto.response.WaitingGiftBoxResponse;
-import com.dilly.global.util.SecurityUtil;
 import com.dilly.global.util.validator.UuidValidator;
-import com.dilly.member.adaptor.MemberReader;
+import com.dilly.member.application.MemberService;
 import com.dilly.member.domain.Member;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -69,6 +68,8 @@ public class GiftBoxService {
 
     private final GiftBoxActionProvider giftBoxActionProvider;
 
+    private final MemberService memberService;
+
     private final GiftBoxReader giftBoxReader;
     private final GiftBoxWriter giftBoxWriter;
     private final BoxReader boxReader;
@@ -78,15 +79,13 @@ public class GiftBoxService {
     private final PhotoWriter photoWriter;
     private final GiftBoxStickerReader giftBoxStickerReader;
     private final GiftBoxStickerWriter giftBoxStickerWriter;
-    private final MemberReader memberReader;
     private final ReceiverReader receiverReader;
     private final AdminGiftBoxReader adminGiftBoxReader;
     private final LastViewedAdminTypeReader lastViewedAdminTypeReader;
     private final LastViewedAdminTypeWriter lastViewedAdminTypeWriter;
 
     public GiftBoxIdResponse createGiftBox(GiftBoxRequest giftBoxRequest) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member sender = memberReader.findById(memberId);
+        Member sender = memberService.getMember();
 
         Box box = boxReader.findById(giftBoxRequest.boxId());
         Envelope envelope = envelopeReader.findById(giftBoxRequest.envelopeId());
@@ -122,8 +121,7 @@ public class GiftBoxService {
     }
 
     public GiftBoxResponse openGiftBox(Long giftBoxId) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
         GiftBox giftBox = giftBoxReader.findById(giftBoxId);
 
         MemberRole memberRole = getMemberRole(member, giftBox);
@@ -167,8 +165,7 @@ public class GiftBoxService {
     // TODO: 성능 개선 필요
     public Slice<GiftBoxesResponse> getGiftBoxes(LocalDateTime lastGiftBoxDate, String type,
         Pageable pageable) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         if (type == null) {
             type = "all";
@@ -244,8 +241,7 @@ public class GiftBoxService {
     }
 
     public String deleteGiftBox(Long giftBoxId) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         GiftBox giftBox = giftBoxReader.findById(giftBoxId);
         MemberRole memberRole = getMemberRole(member, giftBox);
@@ -275,8 +271,7 @@ public class GiftBoxService {
     }
 
     public String updateDeliverStatus(Long giftBoxId, DeliverStatusRequest deliverStatusRequest) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         GiftBox giftBox = giftBoxReader.findById(giftBoxId);
 
@@ -297,8 +292,7 @@ public class GiftBoxService {
     }
 
     public List<WaitingGiftBoxResponse> getWaitingGiftBoxes() {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         return giftBoxReader.findTop6BySenderAndDeliverStatusAndSenderDeletedOrderByCreatedAtDesc(
                 member, DeliverStatus.WAITING).stream()
@@ -312,8 +306,7 @@ public class GiftBoxService {
     }
 
     public MainGiftBoxResponse getMainGiftBox() {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         Optional<LastViewedAdminType> lastViewedAdminType = lastViewedAdminTypeReader.findByMember(
             member);

--- a/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
+++ b/packy-api/src/main/java/com/dilly/gift/application/GiftService.java
@@ -12,8 +12,7 @@ import com.dilly.gift.dto.response.GiftResponseDto.ItemResponse;
 import com.dilly.gift.dto.response.LetterResponse;
 import com.dilly.gift.dto.response.MusicResponse;
 import com.dilly.gift.dto.response.PhotoResponseDto.PhotoWithoutSequenceResponse;
-import com.dilly.global.util.SecurityUtil;
-import com.dilly.member.adaptor.MemberReader;
+import com.dilly.member.application.MemberService;
 import com.dilly.member.domain.Member;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
@@ -31,15 +30,15 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class GiftService {
 
-    private final MemberReader memberReader;
+    private final MemberService memberService;
+
     private final GiftBoxReader giftBoxReader;
     private final PhotoReader photoReader;
     private final LetterReader letterReader;
     private final ReceiverReader receiverReader;
 
     public Slice<PhotoWithoutSequenceResponse> getPhotos(Long lastPhotoId, Pageable pageable) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         LocalDateTime lastPhotoDate = LocalDateTime.now();
         if (lastPhotoId != null) {
@@ -59,8 +58,7 @@ public class GiftService {
     }
 
     public Slice<LetterResponse> getLetters(Long lastLetterId, Pageable pageable) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         LocalDateTime lastLetterDate = LocalDateTime.now();
         if (lastLetterId != null) {
@@ -80,8 +78,7 @@ public class GiftService {
     }
 
     public Slice<MusicResponse> getMusics(Long lastGiftBoxId, Pageable pageable) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         LocalDateTime lastGiftBoxDate = LocalDateTime.now();
         if (lastGiftBoxId != null) {
@@ -101,8 +98,7 @@ public class GiftService {
     }
 
     public Slice<ItemResponse> getItems(Long lastGiftBoxId, Pageable pageable) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         LocalDateTime lastGiftBoxDate = LocalDateTime.now();
         if (lastGiftBoxId != null) {

--- a/packy-api/src/main/java/com/dilly/global/util/SecurityUtil.java
+++ b/packy-api/src/main/java/com/dilly/global/util/SecurityUtil.java
@@ -1,7 +1,7 @@
 package com.dilly.global.util;
 
-import com.dilly.exception.AuthorizationFailedException;
 import com.dilly.exception.ErrorCode;
+import com.dilly.exception.authorizationfailed.AuthorizationFailedException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/packy-api/src/main/java/com/dilly/jwt/JwtService.java
+++ b/packy-api/src/main/java/com/dilly/jwt/JwtService.java
@@ -1,7 +1,7 @@
 package com.dilly.jwt;
 
-import com.dilly.exception.AuthorizationFailedException;
 import com.dilly.exception.ErrorCode;
+import com.dilly.exception.authorizationfailed.AuthorizationFailedException;
 import com.dilly.jwt.adaptor.JwtReader;
 import com.dilly.jwt.adaptor.JwtWriter;
 import com.dilly.jwt.dto.JwtRequest;

--- a/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
+++ b/packy-api/src/main/java/com/dilly/jwt/TokenProvider.java
@@ -1,7 +1,7 @@
 package com.dilly.jwt;
 
-import com.dilly.exception.AuthorizationFailedException;
 import com.dilly.exception.ErrorCode;
+import com.dilly.exception.authorizationfailed.AuthorizationFailedException;
 import com.dilly.jwt.dto.JwtResponse;
 import com.dilly.member.domain.Member;
 import io.jsonwebtoken.Claims;

--- a/packy-api/src/main/java/com/dilly/member/application/MemberService.java
+++ b/packy-api/src/main/java/com/dilly/member/application/MemberService.java
@@ -38,8 +38,8 @@ public class MemberService {
     }
 
     public AppStatusResponse getStatus(String appVersion) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = getMember();
+        Long memberId = member.getId();
 
         // 유저 계정 상태 확인
         if (!member.getStatus().equals(Status.REGISTERED)) {

--- a/packy-api/src/main/java/com/dilly/member/application/MemberService.java
+++ b/packy-api/src/main/java/com/dilly/member/application/MemberService.java
@@ -4,6 +4,7 @@ import static com.dilly.global.constant.Constants.MINIMUM_REQUIRED_VERSION;
 
 import com.dilly.exception.BadRequestException;
 import com.dilly.exception.ErrorCode;
+import com.dilly.exception.authorizationfailed.AuthorizationFailedException;
 import com.dilly.exception.internalserver.InternalServerException;
 import com.dilly.global.util.SecurityUtil;
 import com.dilly.member.adaptor.MemberReader;
@@ -23,6 +24,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberReader memberReader;
+
+    public Member getMember() {
+        Long memberId = SecurityUtil.getMemberId();
+        Member member = memberReader.findById(memberId);
+
+        Boolean isValidMember = member.getStatus().equals(Status.REGISTERED);
+        if (Boolean.FALSE.equals(isValidMember)) {
+            throw new AuthorizationFailedException(ErrorCode.INVALID_MEMBER);
+        }
+
+        return member;
+    }
 
     public AppStatusResponse getStatus(String appVersion) {
         Long memberId = SecurityUtil.getMemberId();

--- a/packy-api/src/main/java/com/dilly/member/application/MyPageService.java
+++ b/packy-api/src/main/java/com/dilly/member/application/MyPageService.java
@@ -1,6 +1,5 @@
 package com.dilly.member.application;
 
-import com.dilly.global.util.SecurityUtil;
 import com.dilly.member.adaptor.MemberReader;
 import com.dilly.member.adaptor.ProfileImageReader;
 import com.dilly.member.domain.Member;
@@ -18,19 +17,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class MyPageService {
 
+    private final MemberService memberService;
+
     private final MemberReader memberReader;
     private final ProfileImageReader profileImageReader;
 
     public ProfileResponse getProfile() {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         return ProfileResponse.from(member);
     }
 
     public ProfileResponse updateProfile(ProfileRequest profileRequest) {
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         Optional.ofNullable(profileRequest.nickname())
             .ifPresent(member::updateNickname);

--- a/packy-api/src/test/java/com/dilly/auth/application/AuthServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/auth/application/AuthServiceTest.java
@@ -44,7 +44,7 @@ class AuthServiceTest extends IntegrationTestSupport {
 
     @DisplayName("올바르지 않은 Provider Type으로 회원가입을 요청할 경우 예외가 발생한다.")
     @Test
-    void throwExceptionWithWrongProviderType() {
+    void signUpThrowExceptionWithWrongProviderType() {
         // given
         String providerAccessToken = TEST_ACCESS_TOKEN;
         String wrongProvider = "wrong";

--- a/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
@@ -28,6 +28,7 @@ import com.dilly.jwt.adaptor.JwtWriter;
 import com.dilly.member.adaptor.MemberReader;
 import com.dilly.member.adaptor.MemberWriter;
 import com.dilly.member.adaptor.ProfileImageReader;
+import com.dilly.member.application.MemberService;
 import com.dilly.member.application.MyPageService;
 import jakarta.transaction.Transactional;
 import java.time.Clock;
@@ -73,6 +74,9 @@ public abstract class IntegrationTestSupport {
 
     @Autowired
     protected MyPageService myPageService;
+
+    @Autowired
+    protected MemberService memberService;
 
     @Autowired
     protected TokenProvider tokenProvider;

--- a/packy-api/src/test/java/com/dilly/member/application/MemberServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/member/application/MemberServiceTest.java
@@ -1,0 +1,55 @@
+package com.dilly.member.application;
+
+import static com.dilly.MemberEnumFixture.NORMAL_MEMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.dilly.exception.authorizationfailed.AuthorizationFailedException;
+import com.dilly.global.IntegrationTestSupport;
+import com.dilly.global.WithCustomMockUser;
+import com.dilly.jwt.RefreshToken;
+import com.dilly.member.domain.Member;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberServiceTest extends IntegrationTestSupport {
+
+    private Member member;
+
+    private final String MEMBER_ID = "1";
+
+    @BeforeEach
+    void setUp() {
+        Long memberId = Long.parseLong(MEMBER_ID);
+        member = memberWriter.save(NORMAL_MEMBER.createMember(memberId));
+    }
+
+    @DisplayName("유저의 엔티티를 조회한다")
+    @Test
+    @WithCustomMockUser(id = MEMBER_ID)
+    void getMember() {
+        // when
+        Member result = memberService.getMember();
+
+        // then
+        assertThat(result).isEqualTo(member);
+    }
+
+    @DisplayName("탈퇴한 유저의 엔티티를 조회할 경우 예외를 던진다")
+    @Test
+    @WithCustomMockUser(id = MEMBER_ID)
+    void getMemberThrowExceptionForWithdrawnMember() {
+        // given
+        jwtWriter.save(RefreshToken.builder()
+                .member(member)
+                .refreshToken("test")
+                .build());
+
+        authService.withdraw();
+
+        // when // then
+        assertThatThrownBy(() -> memberService.getMember())
+            .isInstanceOf(AuthorizationFailedException.class);
+    }
+}

--- a/packy-api/src/test/java/com/dilly/mypage/application/MyPageServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/mypage/application/MyPageServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.dilly.global.IntegrationTestSupport;
 import com.dilly.global.WithCustomMockUser;
-import com.dilly.global.util.SecurityUtil;
 import com.dilly.member.domain.Member;
 import com.dilly.member.dto.request.ProfileRequest;
 import com.dilly.member.dto.response.ProfileResponse;
@@ -19,8 +18,7 @@ class MyPageServiceTest extends IntegrationTestSupport {
     @WithCustomMockUser
     void getProfile() {
         // given
-        Long memberId = SecurityUtil.getMemberId();
-        Member member = memberReader.findById(memberId);
+        Member member = memberService.getMember();
 
         // when
         ProfileResponse response = myPageService.getProfile();

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
 
     // Member
     MEMBER_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 가입된 유저입니다."),
+    INVALID_MEMBER(HttpStatus.UNAUTHORIZED, "유효하지 않은 유저입니다."),
 
     // GiftBox
     BOX_NOT_FOUND(HttpStatus.NOT_FOUND, "선물 박스를 찾을 수 없습니다."),

--- a/packy-common/src/main/java/com/dilly/exception/authorizationfailed/AuthorizationFailedException.java
+++ b/packy-common/src/main/java/com/dilly/exception/authorizationfailed/AuthorizationFailedException.java
@@ -1,4 +1,7 @@
-package com.dilly.exception;
+package com.dilly.exception.authorizationfailed;
+
+import com.dilly.exception.BusinessException;
+import com.dilly.exception.ErrorCode;
 
 public class AuthorizationFailedException extends BusinessException {
 

--- a/packy-domain/src/main/java/com/dilly/member/adaptor/MemberReader.java
+++ b/packy-domain/src/main/java/com/dilly/member/adaptor/MemberReader.java
@@ -1,5 +1,7 @@
 package com.dilly.member.adaptor;
 
+import com.dilly.exception.ErrorCode;
+import com.dilly.exception.authorizationfailed.AuthorizationFailedException;
 import com.dilly.exception.entitynotfound.MemberNotFoundException;
 import com.dilly.member.MemberRepository;
 import com.dilly.member.domain.Member;
@@ -14,6 +16,12 @@ public class MemberReader {
 	private final MemberRepository memberRepository;
 
 	public Member findById(Long id) {
+		Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+
+		Boolean isValidMember = member.getStatus().equals(Status.REGISTERED);
+		if (Boolean.FALSE.equals(isValidMember)) {
+			throw new AuthorizationFailedException(ErrorCode.INVALID_MEMBER);
+		}
 		return memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
 	}
 

--- a/packy-domain/src/main/java/com/dilly/member/adaptor/MemberReader.java
+++ b/packy-domain/src/main/java/com/dilly/member/adaptor/MemberReader.java
@@ -1,7 +1,5 @@
 package com.dilly.member.adaptor;
 
-import com.dilly.exception.ErrorCode;
-import com.dilly.exception.authorizationfailed.AuthorizationFailedException;
 import com.dilly.exception.entitynotfound.MemberNotFoundException;
 import com.dilly.member.MemberRepository;
 import com.dilly.member.domain.Member;
@@ -16,12 +14,6 @@ public class MemberReader {
 	private final MemberRepository memberRepository;
 
 	public Member findById(Long id) {
-		Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
-
-		Boolean isValidMember = member.getStatus().equals(Status.REGISTERED);
-		if (Boolean.FALSE.equals(isValidMember)) {
-			throw new AuthorizationFailedException(ErrorCode.INVALID_MEMBER);
-		}
 		return memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
 	}
 


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 문제 상황: 유저 인증 정보가 필요할 경우, 아래 코드처럼 SecurityUtil로 토큰에서 memberId 정보를 가져와 Member 엔티티를 조회한 뒤 사용하고 있습니다. 회원 탈퇴로 soft delete 처리된 유저와 관련된 예외 처리가 없어 탈퇴한 유저의 토큰으로도 API 사용이 가능합니다.
- 해결 방법: SecurityUtil에서 가져온 memberId로 Member 엔티티를 조회하는 코드를 MemberService로 옮기고, status 필드를 사용하여 유효한 유저인지 검증하는 로직을 추가하였습니다.

- 추가 작업 사항: ERD에 반영되지 않은 엔티티 변경사항을 반영하였습니다. a4d5c631cff4c8a252b696508aa09c10ab9539f1
 
## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
