### PR TITLE
refactor: Github Actions 워크플로우 리팩토링

### DIFF
--- a/.github/workflows/packy-cd-dev.yml
+++ b/.github/workflows/packy-cd-dev.yml
@@ -5,64 +5,9 @@ on:
     branches:
       - develop
 
-permissions:
-  contents: read
-
 jobs:
   CD:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.ACTION_TOKEN }}
-          submodules: true
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-
-      - name: Build with Gradle & Upload Image to ECR
-        run: ./gradlew -Pdev clean jib
-
-      - name: Get current time
-        uses: josStorer/get-current-time@v2
-        id: current-time
-        with:
-          format: YYYYMMDD_HH-mm-ss
-          utcOffset: "+09:00"
-
-      - name: Generate deployment package
-        run: |
-          mkdir -p deploy/.platform/nginx/conf.d
-          cp Dockerrun.aws.dev.json deploy/Dockerrun.aws.json
-          cp -r .ebextensions-dev deploy/.ebextensions
-          cp .platform/nginx/conf.d/proxy-dev.conf deploy/.platform/nginx/conf.d/proxy.conf
-          cd deploy && zip -r deploy.zip .
-
-      - name: Beanstalk Deploy
-        uses: einaregilsson/beanstalk-deploy@v21
-        with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          application_name: packy-dev-beanstalk
-          environment_name: Packy-dev-beanstalk-env
-          version_label: packy-dev-${{steps.current-time.outputs.formattedTime}}
-          region: ${{ secrets.AWS_REGION }}
-          deployment_package: deploy/deploy.zip
-          wait_for_environment_recovery: 200
+    name: Call Reusable Deploy Workflow
+    uses: ./.github/workflows/reusable-cd.yml
+    with:
+      profile: dev

--- a/.github/workflows/packy-cd-prod.yml
+++ b/.github/workflows/packy-cd-prod.yml
@@ -5,67 +5,13 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 jobs:
   CD:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.ACTION_TOKEN }}
-          submodules: true
+    name: Call Reusable Deploy Workflow
+    uses: ./.github/workflows/reusable-cd.yml
+    with:
+      profile: dev
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
-
-      - name: Build with Gradle & Upload Image to ECR
-        run: ./gradlew -Pprod clean jib
-
-      - name: Get current time
-        uses: josStorer/get-current-time@v2
-        id: current-time
-        with:
-          format: YYYYMMDD_HH-mm-ss
-          utcOffset: "+09:00"
-
-      - name: Generate deployment package
-        run: |
-          mkdir -p deploy/.platform/nginx/conf.d
-          cp Dockerrun.aws.prod.json deploy/Dockerrun.aws.json
-          cp -r .ebextensions-prod deploy/.ebextensions
-          cp .platform/nginx/conf.d/proxy-prod.conf deploy/.platform/nginx/conf.d/proxy.conf
-          cd deploy && zip -r deploy.zip .
-
-      - name: Beanstalk Deploy
-        uses: einaregilsson/beanstalk-deploy@v21
-        with:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          application_name: packy-prod-beanstalk
-          environment_name: Packy-prod-beanstalk-env
-          version_label: packy-prod-${{steps.current-time.outputs.formattedTime}}
-          region: ${{ secrets.AWS_REGION }}
-          deployment_package: deploy/deploy.zip
-          wait_for_environment_recovery: 200
 
 #      - name: Update Release
 #        uses: release-drafter/release-drafter@v5

--- a/.github/workflows/packy-ci.yml
+++ b/.github/workflows/packy-ci.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Run build with Gradle Wrapper
         run: ./gradlew clean build --parallel

--- a/.github/workflows/packy-ci.yml
+++ b/.github/workflows/packy-ci.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
       - develop
-  push:
-    branches:
-      - main
-      - develop
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -1,0 +1,76 @@
+name: Reusable Deploy Workflow
+
+permissions:
+  contents: read
+on:
+  workflow_call:
+    inputs:
+      profile:
+        type: string
+        required: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ACTION_TOKEN }}
+          submodules: true
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v3
+
+      - name: Build with Gradle & Upload Image to ECR
+        run: ./gradlew -P${{ inputs.profile }} clean jib
+
+      - name: Get current time
+        uses: josStorer/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYYMMDD_HH-mm-ss
+          utcOffset: "+09:00"
+
+      - name: Generate deployment package
+        run: |
+          mkdir -p deploy/.platform/nginx/conf.d
+          cp Dockerrun.aws.${{ inputs.profile }}.json deploy/Dockerrun.aws.json
+          cp -r .ebextensions-${{ inputs.profile }} deploy/.ebextensions
+          cp .platform/nginx/conf.d/proxy-${{ inputs.profile }}.conf deploy/.platform/nginx/conf.d/proxy.conf
+          cd deploy && zip -r deploy.zip .
+
+      - name: Beanstalk Deploy
+        uses: einaregilsson/beanstalk-deploy@v21
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: packy-${{ inputs.profile }}-beanstalk
+          environment_name: Packy-${{ inputs.profile }}-beanstalk-env
+          version_label: packy-${{ inputs.profile }}-${{steps.current-time.outputs.formattedTime}}
+          region: ${{ secrets.AWS_REGION }}
+          deployment_package: deploy/deploy.zip
+          wait_for_environment_recovery: 200
+
+
+      - name: Report to CodeCov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: 'packy-support/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml'

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -36,7 +36,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle & Upload Image to ECR
         run: ./gradlew -P${{ inputs.profile }} clean jib

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -57,7 +57,7 @@ jobs:
           cd deploy && zip -r deploy.zip .
 
       - name: Beanstalk Deploy
-        uses: einaregilsson/beanstalk-deploy@v21
+        uses: einaregilsson/beanstalk-deploy@v22
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## 🛰️ Issue Number
#252 

## 🪐 작업 내용
- 워크플로우 실행 시 발생하는 Warning을 해결하기 위해 워크플로우를 수정하였습니다.
  - Gradle 빌드 시 setup-gradle@v4 사용 57ce6a63ed70251ce8c975e30e465ed3eb8a4a1e
  - beanstalk-deploy 버전을 22로 업그레이드 fb40699fe14dcb97a77367d61b8381f089f54c9f
- Codecov 연동 문제로 push 이벤트 발생 시 CI 워크플로우를 실행시키던 것을 CD 워크플로우에 Codecov 리포트 step을 추가하는 것으로 변경하였습니다. ccc25c5d3196f6190cd79b6664252bd1f576bb92
- CD 워크플로우가 profile만 다르고 내용은 동일하기 때문에 workflow_call 기능을 사용하여 워크플로우를 재사용하도록 워크플로우 구조를 수정하였습니다.  225f66da783c2d14e2da3f6a25740633c7e35383

## 📚 Reference
- https://marshallku.com/dev/reuse-github-actions
- https://blog.outsider.ne.kr/1591
- https://velog.io/@chldmswnl/Github-action%EC%97%90%EC%84%9C-workflow%EB%A5%BC-%EC%9E%AC%EC%82%AC%EC%9A%A9%ED%95%B4-%EB%B3%B4%EC%9E%90

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
