### PR TITLE
fix: Github Actions 테스트 커버리지 측정 방식 변경

### DIFF
--- a/.github/workflows/packy-ci.yml
+++ b/.github/workflows/packy-ci.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Run build with Gradle Wrapper
         run: ./gradlew clean build --parallel
 
-      - name: Report to CodeCov
-        uses: codecov/codecov-action@v4
+      - name: Add coverage to PR
+        uses: madrapps/jacoco-report@v1.6.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: 'packy-support/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml'
+          paths: ${{ github.workspace }}/packy-support/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          token: ${{ secrets.ACTION_TOKEN }}

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -78,10 +78,3 @@ jobs:
           region: ${{ secrets.AWS_REGION }}
           deployment_package: deploy/deploy.zip
           wait_for_environment_recovery: 200
-
-
-      - name: Report to CodeCov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: 'packy-support/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml'


### PR DESCRIPTION
## 🛰️ Issue Number
#277 

## 🪐 작업 내용
- CD 스크립트에서 테스트 커버리지 측정 단계를 제거했습니다. (codecov를 사용했을 때 Comment에 커버리지 변경이 반영되지 않아 추가했던 단계였습니다.)
- CI 스크립트의 테스트 커버리지 측정 시 [madrapps/jacoco-report](https://github.com/Madrapps/jacoco-report)를 사용하도록 변경하였습니다.
- Secrets에서 codecov 토큰을 삭제했습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
