### PR TITLE
deploy: CD 워크플로우 성공 시 슬랙 알림 전송

### DIFF
--- a/.github/workflows/packy-cd-dev.yml
+++ b/.github/workflows/packy-cd-dev.yml
@@ -16,4 +16,5 @@ jobs:
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+      SLACK_WEBHOOK: ${{ ssecrets.SLACK_WEBHOOK }}

--- a/.github/workflows/packy-cd-prod.yml
+++ b/.github/workflows/packy-cd-prod.yml
@@ -16,8 +16,8 @@ jobs:
       AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
+      SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
+      SLACK_WEBHOOK: ${{ ssecrets.SLACK_WEBHOOK }}
 #      - name: Update Release
 #        uses: release-drafter/release-drafter@v5
 #        with:

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -17,9 +17,10 @@ on:
         required: true
       AWS_REGION:
         required: true
-      CODECOV_TOKEN:
+      SLACK_CHANNEL:
         required: true
-
+      SLACK_WEBHOOK:
+        required: true
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -78,3 +79,22 @@ jobs:
           region: ${{ secrets.AWS_REGION }}
           deployment_package: deploy/deploy.zip
           wait_for_environment_recovery: 200
+
+      - name: Set Slack profile based on branch
+        run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            echo "SLACK_PROFILE=운영계" >> $GITHUB_ENV
+          elif [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
+            echo "SLACK_PROFILE=개발계" >> $GITHUB_ENV
+          fi
+      - name: Notify message to Slack
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: $ {{ secrets.SLACK_CHANNEL }}
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_USERNAME: API 서버를 업데이트 했어요
+          SLACK_ICON: https://i.pinimg.com/236x/86/ac/ae/86acaefa1fff543ad4b49ed39a2f38bc.jpg
+          SLACK_TITLE: ${{ env.SLACK_PROFILE }} 서버 변경 사항
+          SLACK_MESSAGE: ${{ github.workflow }}

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -22,7 +22,7 @@ on:
       SLACK_WEBHOOK:
         required: true
 jobs:
-  run:
+  CD:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -87,8 +87,11 @@ jobs:
           elif [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
             echo "SLACK_PROFILE=개발계" >> $GITHUB_ENV
           fi
-      - name: Notify message to Slack
-        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+  SlackNotify:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Message to Slack
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## 🛰️ Issue Number
#282 

## 🪐 작업 내용
Github Actions CD 스크립트를 수정했습니다.
- #278 에서 제거하지 않아 남아있던 codecov 관련 설정을 제거하였습니다.
- [rtCamp/action-slack-notify@v2](https://github.com/rtCamp/action-slack-notify)를 사용하여 워크플로우 성공 시 슬랙으로 알림을 전송하는 작업을 추가했습니다.

## 📚 Reference
- https://modolee-blog.tistory.com/18
- https://docs.github.com/ko/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
