### PR TITLE
fix: Github Actions 슬랙 알림 전송 

### DIFF
--- a/.github/workflows/packy-cd-dev.yml
+++ b/.github/workflows/packy-cd-dev.yml
@@ -17,4 +17,4 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
-      SLACK_WEBHOOK: ${{ ssecrets.SLACK_WEBHOOK }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -89,7 +89,7 @@ jobs:
           fi
   SlackNotify:
     needs: CD
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ needs.CD.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Notify Message to Slack

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -88,6 +88,7 @@ jobs:
             echo "SLACK_PROFILE=개발계" >> $GITHUB_ENV
           fi
   SlackNotify:
+    needs: CD
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 🛰️ Issue Number
#282 #283 

## 🪐 작업 내용
- CD와 SlackNotify Job 사이 순서를 지정했습니다.
- 오타를 수정했습니다.

## 📚 Reference
- https://velog.io/@gidskql6671/Github-Actions-Job%EB%93%A4%EC%9D%98-%EC%8B%A4%ED%96%89-%EC%88%9C%EC%84%9C-%EC%A0%95%ED%95%B4%EC%A3%BC%EA%B8%B0

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
