### PR TITLE
fix: Github Actions 슬랙 알림 전송 워크플로우 수정 

### DIFF
--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -97,7 +97,5 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: $ {{ secrets.SLACK_CHANNEL }}
           SLACK_COLOR: ${{ job.status }}
-          SLACK_USERNAME: API 서버를 업데이트 했어요
-          SLACK_ICON: https://i.pinimg.com/236x/86/ac/ae/86acaefa1fff543ad4b49ed39a2f38bc.jpg
           SLACK_TITLE: ${{ env.SLACK_PROFILE }} 서버 변경 사항
           SLACK_MESSAGE: ${{ github.workflow }}

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -79,7 +79,11 @@ jobs:
           region: ${{ secrets.AWS_REGION }}
           deployment_package: deploy/deploy.zip
           wait_for_environment_recovery: 200
-
+  SlackNotify:
+    needs: CD
+    if: ${{ needs.CD.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Set Slack profile based on branch
         run: |
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
@@ -87,11 +91,6 @@ jobs:
           elif [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
             echo "SLACK_PROFILE=개발계" >> $GITHUB_ENV
           fi
-  SlackNotify:
-    needs: CD
-    if: ${{ needs.CD.result == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
       - name: Notify Message to Slack
         uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
## 🛰️ Issue Number
#282 #283 #284

## 🪐 작업 내용
- `Set Slack profile based on branch` 단계를 SlackNotify 작업으로 옮겼습니다.
  - [GitHub docs](https://docs.github.com/ko/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions)에 따르면 $GITHUB_ENV는 특정 `작업`을 수행하는 데 사용할 수 있는 임시 파일입니다.
- SLACK_USERNAME, SLACK_ICON을 env에서 제거하였습니다. 

## 📚 Reference
- https://docs.github.com/ko/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
