### PR TITLE
fix: 배포 성공 슬랙 알림 전송 메시지 포맷 변경

### DIFF
--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -97,7 +97,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           SLACK_COLOR: ${{ job.status }}
-          SLACK_TITLE: ${{ env.SLACK_PROFILE }} 서버 변경 사항
-          SLACK_MESSAGE: ${{ github.workflow }}
           SLACK_USERNAME: API 서버를 업데이트 했어요
           SLACK_ICON: https://i.pinimg.com/236x/86/ac/ae/86acaefa1fff543ad4b49ed39a2f38bc.jpg
+          SLACK_TITLE: 🎁 ${{ env.SLACK_PROFILE }} 서버 변경 사항 🎁
+          SLACK_MESSAGE: ${{ github.event.head_commit.message }}

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -99,3 +99,5 @@ jobs:
           SLACK_COLOR: ${{ job.status }}
           SLACK_TITLE: ${{ env.SLACK_PROFILE }} 서버 변경 사항
           SLACK_MESSAGE: ${{ github.workflow }}
+          SLACK_USERNAME: API 서버를 업데이트 했어요
+          SLACK_ICON: https://i.pinimg.com/236x/86/ac/ae/86acaefa1fff543ad4b49ed39a2f38bc.jpg


### PR DESCRIPTION
## 🛰️ Issue Number
#282 

## 🪐 작업 내용
<img width="505" alt="image" src="https://github.com/user-attachments/assets/846a8ce6-cc80-411b-83a9-4472e7ba0630">

슬랙 메시지가 원하는대로 전송되지 않아 env 값을 수정했습니다.

1. SLACK_USERNAME과 SLACK_ICON을 다시 추가했습니다.
2. SLACK_TITLE과 SLACK_MESSAGE를 수정했습니다.

## 📚 Reference
- https://stackoverflow.com/questions/72403591/name-of-github-action-run-in-list

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
