### PR TITLE
fix: 공지사항 단일 조회 API 토큰 없이 접근 가능하도록 변경

### DIFF
--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -79,7 +79,7 @@ jobs:
           region: ${{ secrets.AWS_REGION }}
           deployment_package: deploy/deploy.zip
           wait_for_environment_recovery: 200
-  SlackNotify:
+  SlackNotification:
     needs: CD
     if: ${{ needs.CD.result == 'success' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-cd.yml
+++ b/.github/workflows/reusable-cd.yml
@@ -91,6 +91,13 @@ jobs:
           elif [[ "${GITHUB_REF}" == "refs/heads/develop" ]]; then
             echo "SLACK_PROFILE=개발계" >> $GITHUB_ENV
           fi
+
+      - name: Extract commit message title
+        run: |
+          COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
+          COMMIT_TITLE=$(echo "$COMMIT_MESSAGE" | head -n 1)
+          echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV
+
       - name: Notify Message to Slack
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -100,4 +107,4 @@ jobs:
           SLACK_USERNAME: API 서버를 업데이트 했어요
           SLACK_ICON: https://i.pinimg.com/236x/86/ac/ae/86acaefa1fff543ad4b49ed39a2f38bc.jpg
           SLACK_TITLE: 🎁 ${{ env.SLACK_PROFILE }} 서버 변경 사항 🎁
-          SLACK_MESSAGE: ${{ github.event.head_commit.message }}
+          SLACK_MESSAGE: ${{ env.COMMIT_TITLE }}

--- a/packy-api/src/main/java/com/dilly/global/config/SecurityConfig.java
+++ b/packy-api/src/main/java/com/dilly/global/config/SecurityConfig.java
@@ -63,12 +63,13 @@ public class SecurityConfig {
 						"/api/v1/admin/health",
 						"/api/v1/auth/token/kakao/**",
 						"/api/v1/admin/design/profiles",
+						"/api/v1/admin/branch",
+						"/api/v1/admin/notices/web/**",
 						"/api/v1/auth/sign-up",
 						"/api/v1/auth/sign-in/**",
 						"/api/v1/auth/reissue",
 						"/api/v1/auth/withdraw/kakao",
-						"/api/v1/giftboxes/web/**",
-						"/api/v1/admin/branch"
+						"/api/v1/giftboxes/web/**"
 					).permitAll()
 					.anyRequest().authenticated()
 			)


### PR DESCRIPTION
## 🛰️ Issue Number
#275

## 🪐 작업 내용
- 공지사항 단일 조회 API는 웹에서 사용해야 하므로 토큰 없이 접근 가능하도록 SecurityConfig를 수정하였습니다.
- GitHub Actions 슬랙 알림 전송 시 메시지에 PR 제목만 출력되도록 스크립트를 수정하였습니다.

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
