### PR TITLE
feat: 설정 링크 조회 API v2 구현

### DIFF
--- a/db.vuerd.json
+++ b/db.vuerd.json
@@ -4,8 +4,8 @@
   "settings": {
     "width": 2500,
     "height": 2500,
-    "scrollTop": -535,
-    "scrollLeft": -254.4,
+    "scrollTop": -673,
+    "scrollLeft": -567.4,
     "zoomLevel": 0.8,
     "show": 431,
     "database": 4,
@@ -453,11 +453,13 @@
         "comment": "설정",
         "columnIds": [
           "d4ea9e4e-2913-4129-a1b3-e027100c110e",
+          "K6-LZgEMwEhGvBSkPJUp5",
           "feaf62d7-bbd7-4969-988a-4c207864dd9d",
           "8ab44e4f-0a67-4f7b-ba0f-a3950c02a7c7"
         ],
         "seqColumnIds": [
           "d4ea9e4e-2913-4129-a1b3-e027100c110e",
+          "K6-LZgEMwEhGvBSkPJUp5",
           "feaf62d7-bbd7-4969-988a-4c207864dd9d",
           "8ab44e4f-0a67-4f7b-ba0f-a3950c02a7c7"
         ],
@@ -470,7 +472,7 @@
           "color": ""
         },
         "meta": {
-          "updateAt": 1725271940447,
+          "updateAt": 1726223254893,
           "createAt": 1724811425587
         }
       },
@@ -2097,6 +2099,26 @@
           "updateAt": 1725278015692,
           "createAt": 1725278006200
         }
+      },
+      "K6-LZgEMwEhGvBSkPJUp5": {
+        "id": "K6-LZgEMwEhGvBSkPJUp5",
+        "tableId": "d81ebbcf-fbc5-4e81-a7aa-13cf3c5cab39",
+        "name": "name",
+        "comment": "ex) 패키 공식 SNS",
+        "dataType": "VARCHAR",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 0,
+          "widthName": 60,
+          "widthComment": 95,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1726223256364,
+          "createAt": 1726223243117
+        }
       }
     },
     "relationshipEntities": {
@@ -2615,6 +2637,17 @@
         "name": 1725278009885,
         "dataType": 1725278013500,
         "options(notNull)": 1725278015691
+      }
+    ],
+    "K6-LZgEMwEhGvBSkPJUp5": [
+      "tableColumnEntities",
+      1726223243116,
+      -1,
+      {
+        "name": 1726223245838,
+        "dataType": 1726223248495,
+        "options(notNull)": 1726223249473,
+        "comment": 1726223256363
       }
     ]
   }

--- a/packy-api/src/main/java/com/dilly/admin/api/AdminV2Controller.java
+++ b/packy-api/src/main/java/com/dilly/admin/api/AdminV2Controller.java
@@ -1,0 +1,27 @@
+package com.dilly.admin.api;
+
+import com.dilly.admin.application.AdminV2Service;
+import com.dilly.admin.dto.response.SettingV2Response;
+import com.dilly.global.response.DataResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "관리자 API")
+@RestController
+@RequestMapping("/api/v2/admin")
+@RequiredArgsConstructor
+public class AdminV2Controller {
+
+    private final AdminV2Service adminV2Service;
+
+    @Operation(summary = "설정 링크 조회")
+    @GetMapping("/settings")
+    public DataResponseDto<List<SettingV2Response>> getSettingUrls() {
+        return DataResponseDto.from(adminV2Service.getSettingUrls());
+    }
+}

--- a/packy-api/src/main/java/com/dilly/admin/application/AdminV2Service.java
+++ b/packy-api/src/main/java/com/dilly/admin/application/AdminV2Service.java
@@ -1,0 +1,25 @@
+package com.dilly.admin.application;
+
+import com.dilly.admin.adaptor.SettingReader;
+import com.dilly.admin.domain.setting.Setting;
+import com.dilly.admin.dto.response.SettingV2Response;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class AdminV2Service {
+
+    private final SettingReader settingReader;
+
+    public List<SettingV2Response> getSettingUrls() {
+        List<Setting> settingUrls = settingReader.findAll();
+
+        return settingUrls.stream().map(SettingV2Response::from).toList();
+    }
+}

--- a/packy-api/src/main/java/com/dilly/admin/dto/response/SettingV2Response.java
+++ b/packy-api/src/main/java/com/dilly/admin/dto/response/SettingV2Response.java
@@ -1,0 +1,21 @@
+package com.dilly.admin.dto.response;
+
+import com.dilly.admin.domain.setting.Setting;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record SettingV2Response(
+    @Schema(example = "패키 공식 SNS")
+    String name,
+    @Schema(example = "www.example.com")
+    String url
+) {
+
+    public static SettingV2Response from(Setting setting) {
+        return SettingV2Response.builder()
+            .name(setting.getName())
+            .url(setting.getUrl())
+            .build();
+    }
+}

--- a/packy-api/src/test/java/com/dilly/admin/api/AdminV2ControllerTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/api/AdminV2ControllerTest.java
@@ -1,0 +1,41 @@
+package com.dilly.admin.api;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dilly.admin.dto.response.SettingV2Response;
+import com.dilly.global.ControllerTestSupport;
+import com.dilly.global.WithCustomMockUser;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AdminV2ControllerTest extends ControllerTestSupport {
+
+    @DisplayName("설정 링크를 조회한다.")
+    @Test
+    @WithCustomMockUser
+    void getSettingUrls() throws Exception {
+        // given
+        List<SettingV2Response> settingV2Responses = List.of(
+            SettingV2Response.builder().name("테스트 1").url("www.test1.com").build(),
+            SettingV2Response.builder().name("테스트 2").url("www.test2.com").build(),
+            SettingV2Response.builder().name("테스트 3").url("www.test3.com").build()
+        );
+
+        given(adminV2Service.getSettingUrls()).willReturn(settingV2Responses);
+
+        // when // then
+        mockMvc.perform(
+            get(baseUrlV2 + "/admin/settings")
+        )
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data").isArray())
+        .andExpect(jsonPath("$.data", hasSize(3)));
+    }
+}

--- a/packy-api/src/test/java/com/dilly/admin/application/AdminV2ServiceTest.java
+++ b/packy-api/src/test/java/com/dilly/admin/application/AdminV2ServiceTest.java
@@ -1,0 +1,27 @@
+package com.dilly.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dilly.admin.dto.response.SettingV2Response;
+import com.dilly.global.IntegrationTestSupport;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AdminV2ServiceTest extends IntegrationTestSupport {
+
+    @DisplayName("설정 링크를 조회한다.")
+    @Test
+    void getSettingUrls() {
+        // given
+        List<SettingV2Response> settingUrls = settingReader.findAll()
+            .stream().map(SettingV2Response::from)
+            .toList();
+
+        // when
+        List<SettingV2Response> response = adminV2Service.getSettingUrls();
+
+        // then
+        assertThat(response).isEqualTo(settingUrls);
+    }
+}

--- a/packy-api/src/test/java/com/dilly/global/ControllerTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/ControllerTestSupport.java
@@ -1,7 +1,9 @@
 package com.dilly.global;
 
 import com.dilly.admin.api.AdminController;
+import com.dilly.admin.api.AdminV2Controller;
 import com.dilly.admin.application.AdminService;
+import com.dilly.admin.application.AdminV2Service;
 import com.dilly.application.BranchService;
 import com.dilly.application.YoutubeService;
 import com.dilly.gift.api.GiftBoxController;
@@ -21,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(
 	controllers = {
 		AdminController.class,
+		AdminV2Controller.class,
 		GiftBoxController.class,
 		GiftController.class,
 		MyPageController.class,
@@ -33,6 +36,7 @@ public abstract class ControllerTestSupport {
 	}
 
 	protected final String baseUrl = "/api/v1";
+	protected final String baseUrlV2 = "/api/v2";
 
 	@Autowired
 	protected MockMvc mockMvc;
@@ -42,6 +46,9 @@ public abstract class ControllerTestSupport {
 
 	@MockBean
 	protected AdminService adminService;
+
+	@MockBean
+	protected AdminV2Service adminV2Service;
 
 	@MockBean
 	protected GiftBoxService giftBoxService;

--- a/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
+++ b/packy-api/src/test/java/com/dilly/global/IntegrationTestSupport.java
@@ -7,6 +7,7 @@ import com.dilly.admin.adaptor.NoticeImageReader;
 import com.dilly.admin.adaptor.NoticeReader;
 import com.dilly.admin.adaptor.SettingReader;
 import com.dilly.admin.application.AdminService;
+import com.dilly.admin.application.AdminV2Service;
 import com.dilly.application.FileService;
 import com.dilly.auth.application.AuthService;
 import com.dilly.gift.adaptor.BoxReader;
@@ -64,6 +65,9 @@ public abstract class IntegrationTestSupport {
 
     @Autowired
     protected AdminService adminService;
+
+    @Autowired
+    protected AdminV2Service adminV2Service;
 
     @Autowired
     protected AuthService authService;

--- a/packy-domain/src/main/java/com/dilly/admin/domain/setting/Setting.java
+++ b/packy-domain/src/main/java/com/dilly/admin/domain/setting/Setting.java
@@ -16,6 +16,8 @@ public class Setting {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String name;
+
     @Enumerated(EnumType.STRING)
     private SettingTag settingTag;
 

--- a/packy-flyway/src/main/resources/db/migration/V39__add_name_column_in_setting_table.sql
+++ b/packy-flyway/src/main/resources/db/migration/V39__add_name_column_in_setting_table.sql
@@ -1,0 +1,10 @@
+-- setting 테이블에 name 추가
+alter table setting
+add column name varchar(255);
+
+-- 기존에 있던 설정 이름 추가
+update setting set name = '패키 공식 SNS' where id = 1;
+update setting set name = '1:1 문의하기' where id = 2;
+update setting set name = '패키에게 의견 보내기' where id = 3;
+update setting set name = '이용약관' where id = 4;
+update setting set name = '개인정보처리방침' where id = 5;


### PR DESCRIPTION
## 🛰️ Issue Number
#290

## 🪐 작업 내용
빠른 구현을 위해 Controller와 Service 및 테스트 클래스 이름에 V2를 붙여서 분리하였습니다.
하지만 해당 방법이 최선의 방법이 아니라고 생각이 되어 커스텀 어노테이션 등의 방법으로 추후 리팩토링이 필요합니다.

해당 방법이 최선이 아니라고 생각하는 이유
1. 만약 다른 버전(v1, v2)에서 동일한 함수가 필요할 경우 어느 클래스에 위치할지 애매해지는 문제 발생
2. 버전별 차이가 미미하더라도 새로 코드를 작성해줘야 하므로 중복 코드 발생
3. 버전별 차이를 한눈에 파악할 수 없어 버전별 클래스를 다 확인해봐야 함

## 📚 Reference

## ✅ Check List

- [x] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
