### PR TITLE
feat: FCM 푸시 알림 기능 기본 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,13 +38,16 @@ out/
 
 ### Secrets Managing wit submodule ###
 packy-api/src/main/resources/*.yml
-packy-api/src/main/resources/*.p8
 packy-api/src/main/resources/*.properties
-
 packy-api/src/test/resources/*.sql
+
 packy-domain/src/main/resources/*.yml
 packy-domain/src/main/resources/*.sql
+
 packy-infra/src/main/resources/*.yml
+packy-infra/src/main/resources/*.p8
+packy-infra/src/main/resources/*.json
+
 packy-support/src/main/resources/*.yml
 
 ### QueryDsl QClass ###

--- a/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
+++ b/packy-common/src/main/java/com/dilly/exception/ErrorCode.java
@@ -42,6 +42,9 @@ public enum ErrorCode {
     // Branch
     BRANCH_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Branch 서버 연동에 오류가 발생했습니다."),
 
+    // FCM
+    FCM_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 서버 연동에 오류가 발생했습니다."),
+
     // Authorization
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     MALFORMED_JWT(HttpStatus.UNAUTHORIZED, "올바르지 않은 형식의 JWT 토큰입니다."),
@@ -53,6 +56,7 @@ public enum ErrorCode {
 
     // Not Found
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+    FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "FCM 토큰을 찾을 수 없습니다."),
     STICKER_NOT_FOUND(HttpStatus.NOT_FOUND, "스티커를 찾을 수 없습니다."),
     GIFTBOX_NOT_FOUND(HttpStatus.NOT_FOUND, "선물박스를 찾을 수 없습니다."),
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "사진을 찾을 수 없습니다."),

--- a/packy-domain/src/main/java/com/dilly/member/domain/Device.java
+++ b/packy-domain/src/main/java/com/dilly/member/domain/Device.java
@@ -1,0 +1,22 @@
+package com.dilly.member.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Device {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String token;
+
+    @ManyToOne(fetch = LAZY)
+    private Member member;
+}

--- a/packy-flyway/src/main/resources/db/migration/V40__add_device_table.sql
+++ b/packy-flyway/src/main/resources/db/migration/V40__add_device_table.sql
@@ -1,0 +1,8 @@
+create table device (
+    id bigint not null auto_increment,
+    member_id bigint,
+    token varchar(255),
+    primary key (id)
+);
+
+alter table device add constraint FKs2ah6o1y9r1ox99fh8vj5y0ol foreign key (member_id) references member (id)

--- a/packy-infra/build.gradle
+++ b/packy-infra/build.gradle
@@ -16,6 +16,12 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
+    // webflux (for WebClient)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // test
+    testImplementation 'com.squareup.okhttp3:mockwebserver'
+
     // aws
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
     implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
@@ -35,11 +41,8 @@ dependencies {
     implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
     implementation 'org.bouncycastle:bcpkix-jdk14:1.72'
 
-    // webflux (for WebClient)
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
-    // test
-    testImplementation 'com.squareup.okhttp3:mockwebserver'
+    // fcm
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
 }
 
 test {

--- a/packy-infra/src/main/java/com/dilly/application/FCMNotificationService.java
+++ b/packy-infra/src/main/java/com/dilly/application/FCMNotificationService.java
@@ -1,0 +1,49 @@
+package com.dilly.application;
+
+import com.dilly.dto.request.FCMNotificationRequest;
+import com.dilly.exception.EntityNotFoundException;
+import com.dilly.exception.ErrorCode;
+import com.dilly.exception.internalserver.InternalServerException;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FCMNotificationService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void sendNotificationByToken(List<String> tokens, FCMNotificationRequest fcmNotificationRequest) {
+        if (tokens.isEmpty()) {
+            throw new EntityNotFoundException(ErrorCode.FCM_TOKEN_NOT_FOUND);
+        }
+
+        Notification notification = Notification.builder()
+            .setTitle(fcmNotificationRequest.title())
+            .setBody(fcmNotificationRequest.body())
+            .build();
+
+        List<CompletableFuture<Void>> futures = tokens.stream()
+            .map(token -> CompletableFuture.runAsync(() -> {
+                Message message = Message.builder()
+                    .setToken(token)
+                    .setNotification(notification)
+                    .build();
+
+                try {
+                    firebaseMessaging.send(message);
+                } catch (FirebaseMessagingException e) {
+                    throw new InternalServerException(ErrorCode.FCM_SERVER_ERROR);
+                }
+            }))
+            .toList();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    }
+}

--- a/packy-infra/src/main/java/com/dilly/application/FCMNotificationService.java
+++ b/packy-infra/src/main/java/com/dilly/application/FCMNotificationService.java
@@ -3,7 +3,6 @@ package com.dilly.application;
 import com.dilly.dto.request.FCMNotificationRequest;
 import com.dilly.exception.EntityNotFoundException;
 import com.dilly.exception.ErrorCode;
-import com.dilly.exception.internalserver.InternalServerException;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
@@ -11,8 +10,10 @@ import com.google.firebase.messaging.Notification;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FCMNotificationService {
@@ -39,7 +40,8 @@ public class FCMNotificationService {
                 try {
                     firebaseMessaging.send(message);
                 } catch (FirebaseMessagingException e) {
-                    throw new InternalServerException(ErrorCode.FCM_SERVER_ERROR);
+//                    throw new InternalServerException(ErrorCode.FCM_SERVER_ERROR);
+                    log.error("푸시 알림 전송 실패: " + token, e);
                 }
             }))
             .toList();

--- a/packy-infra/src/main/java/com/dilly/dto/request/FCMNotificationRequest.java
+++ b/packy-infra/src/main/java/com/dilly/dto/request/FCMNotificationRequest.java
@@ -1,0 +1,11 @@
+package com.dilly.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record FCMNotificationRequest(
+    Long targetId,
+    String title,
+    String body
+) {
+}

--- a/packy-infra/src/main/java/com/dilly/global/config/FCMConfig.java
+++ b/packy-infra/src/main/java/com/dilly/global/config/FCMConfig.java
@@ -1,0 +1,41 @@
+package com.dilly.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+public class FCMConfig {
+    @Bean
+    FirebaseMessaging firebaseMessaging() throws IOException {
+        ClassPathResource resource = new ClassPathResource("packy-14a1e-firebase-adminsdk-t9vnt-354e72e63f.json");
+
+        InputStream refrehToken = resource.getInputStream();
+
+        FirebaseApp firebaseApp = null;
+        List<FirebaseApp> firebaseAppList = FirebaseApp.getApps();
+
+        if (firebaseAppList != null && !firebaseAppList.isEmpty()) {
+            for (FirebaseApp app : firebaseAppList) {
+                if (app.getName().equals(FirebaseApp.DEFAULT_APP_NAME)) {
+                    firebaseApp = app;
+                }
+            }
+        } else {
+            FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(refrehToken))
+                .build();
+
+            firebaseApp = FirebaseApp.initializeApp(options);
+        }
+
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#280

## 🪐 작업 내용
FCM 푸시 알림 전송 기능 구현을 위한 기본적인 코드를 구현하였, 자세한 구현 사항은 아래와 같습니다. 
회원가입/로그인 시 FCM 토큰 저장 로직 고도화 작업이 추가적으로 필요합니다.
- 1명의 유저가 여러 단말을 사용하는 상황을 고려하여 Device 엔티티를 추가하였습니다.
- 추후, GiftBoxService 등 필요한 api 모듈의 클래스에서 FCMNotificationService 의존성을 추가하여 사용하면 되도록 구현했습니다.
- 푸시 알림을 여러 기기로 비동기적으로 전송하기 위해 CompletableFuture을 사용하여 비동기적으로 코드를 작성했습니다.
  - 하나의 푸시 알림이 실패하더라도 다른 푸시 알림 전송에 영향을 주지 않게 try-catch의 catch문에서 에러 로그만 출력하도록 했습니다. 에러 로그 출력만으로 충분한지 확실하지 않아 나중에 더 고민해봐야 할 것 같습니다. 

## 📚 Reference
- 가상 면접 사례로 배우는 대규모 시스템 설계 기초
- https://kbwplace.tistory.com/179
- https://11st-tech.github.io/2024/01/04/completablefuture/

## ✅ Check List

- [ ] DB 스키마가 일치하는지 확인했나요?
- [x] SonarLint를 반영하여 코드를 수정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
